### PR TITLE
Implement block range checksum validation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -17,7 +17,8 @@
         * [.parse(value, [options])](#BlockMap+parse) ⇒ <code>[BlockMap](#BlockMap)</code>
     * _static_
         * [.FilterStream](#BlockMap.FilterStream)
-            * [new FilterStream(blockMap, options)](#new_BlockMap.FilterStream_new)
+            * [new FilterStream(blockMap, [options])](#new_BlockMap.FilterStream_new)
+            * [.options](#BlockMap.FilterStream+options) : <code>Object</code>
             * [.blockMap](#BlockMap.FilterStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
             * [.blockSize](#BlockMap.FilterStream+blockSize) : <code>Number</code>
             * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>BlockMap.Range</code>
@@ -28,7 +29,8 @@
             * [.bytesWritten](#BlockMap.FilterStream+bytesWritten) : <code>Number</code>
             * [.position](#BlockMap.FilterStream+position) : <code>Number</code>
         * [.ReadStream](#BlockMap.ReadStream)
-            * [new ReadStream(filename, blockMap, options)](#new_BlockMap.ReadStream_new)
+            * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
+            * [.options](#BlockMap.ReadStream+options) : <code>Object</code>
             * [.path](#BlockMap.ReadStream+path) : <code>String</code>
             * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
             * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
@@ -156,7 +158,8 @@ Parse a .bmap formatted input
 **Kind**: static class of <code>[BlockMap](#BlockMap)</code>  
 
 * [.FilterStream](#BlockMap.FilterStream)
-    * [new FilterStream(blockMap, options)](#new_BlockMap.FilterStream_new)
+    * [new FilterStream(blockMap, [options])](#new_BlockMap.FilterStream_new)
+    * [.options](#BlockMap.FilterStream+options) : <code>Object</code>
     * [.blockMap](#BlockMap.FilterStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
     * [.blockSize](#BlockMap.FilterStream+blockSize) : <code>Number</code>
     * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>BlockMap.Range</code>
@@ -172,14 +175,24 @@ Parse a .bmap formatted input
 
 <a name="new_BlockMap.FilterStream_new"></a>
 
-#### new FilterStream(blockMap, options)
+#### new FilterStream(blockMap, [options])
 FilterStream
 
 **Params**
 
 - blockMap <code>[BlockMap](#BlockMap)</code> - the block map
-- options <code>Object</code> - options
+- [options] <code>Object</code> - options
+    - [.verify] <code>Boolean</code> <code> = true</code> - verify range checksums
 
+
+-
+
+<a name="BlockMap.FilterStream+options"></a>
+
+#### filterStream.options : <code>Object</code>
+options
+
+**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
 
 -
 
@@ -270,7 +283,8 @@ Current offset in bytes
 **Kind**: static class of <code>[BlockMap](#BlockMap)</code>  
 
 * [.ReadStream](#BlockMap.ReadStream)
-    * [new ReadStream(filename, blockMap, options)](#new_BlockMap.ReadStream_new)
+    * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
+    * [.options](#BlockMap.ReadStream+options) : <code>Object</code>
     * [.path](#BlockMap.ReadStream+path) : <code>String</code>
     * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
     * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
@@ -287,16 +301,26 @@ Current offset in bytes
 
 <a name="new_BlockMap.ReadStream_new"></a>
 
-#### new ReadStream(filename, blockMap, options)
+#### new ReadStream(filename, blockMap, [options])
 ReadStream
 
 **Params**
 
 - filename <code>String</code> - image path
 - blockMap <code>[BlockMap](#BlockMap)</code> - image's blockmap
-- options <code>Object</code>
-    - .flags <code>String</code> - fs.open() flags
+- [options] <code>Object</code> - options
+    - [.flags] <code>String</code> <code> = &#x27;r&#x27;</code> - fs.open() flags
+    - [.verify] <code>Boolean</code> <code> = true</code> - verify range checksums
 
+
+-
+
+<a name="BlockMap.ReadStream+options"></a>
+
+#### readStream.options : <code>Object</code>
+options
+
+**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
 
 -
 

--- a/lib/filter-stream.js
+++ b/lib/filter-stream.js
@@ -1,12 +1,14 @@
 var stream = require( 'stream' )
 var inherit = require( 'bloodline' )
+var crypto = require( 'crypto' )
 
 /**
  * FilterStream
  * @constructor
  * @memberOf BlockMap
  * @param {BlockMap} blockMap - the block map
- * @param {Object} options - options
+ * @param {Object} [options] - options
+ * @param {Boolean} [options.verify=true] - verify range checksums
  * @returns {BlockMap.FilterStream}
  */
 function FilterStream( blockMap, options ) {
@@ -19,9 +21,13 @@ function FilterStream( blockMap, options ) {
     throw new Error( 'Missing block map' )
   }
 
-  options = options || {}
+  /** @type {Object} options */
+  this.options = options || {}
 
-  stream.Transform.call( this, options )
+  this.options.verify = this.options.verify != null ?
+    !!this.options.verify : true
+
+  stream.Transform.call( this, this.options )
 
   /** @type {BlockMap} The block map */
   this.blockMap = blockMap
@@ -42,8 +48,28 @@ function FilterStream( blockMap, options ) {
   /** @type {Number} Current offset in bytes */
   this.position = 0
 
+  /**
+   * Internal buffer queue for chunking to block size,
+   * if source does not emit appropriately sized chunks
+   * @type {Buffer[]}
+   * @private
+   */
   this._buffers = []
+
+  /**
+   * Internal buffer's byte counter
+   * @type {Number}
+   * @private
+   */
   this._bytes = 0
+
+  /**
+   * Hash stream to calculate range checksums
+   * @type {crypto.Hash}
+   * @private
+   */
+  this._hash = this.options.verify ?
+    crypto.createHash( this.blockMap.checksumType ) : null
 
 }
 
@@ -69,6 +95,33 @@ function FilterStream( blockMap, options ) {
   },
 
   /**
+   * Verify the current range, if completed,
+   * and emit an error on mismatch
+   * @private
+   */
+  _verifyRange() {
+
+    var needsVerify = this.options.verify &&
+      this.currentRange != null
+
+    if( !needsVerify ) return
+
+    var range = this.currentRange
+    var digest = this._hash.digest( 'hex' )
+    var error = null
+
+    this._hash = crypto.createHash( this.blockMap.checksumType )
+
+    if( range.checksum !== digest ) {
+      error = new Error( 'Invalid checksum for range [' + range.start + ',' + range.end + ']' )
+      error.checksum = digest
+      error.range = range
+      this.emit( 'error', error )
+    }
+
+  },
+
+  /**
    * Push a block out to the readable side,
    * if it's in a mapped range of the block map
    * @private
@@ -83,8 +136,10 @@ function FilterStream( blockMap, options ) {
     if( this.currentRange == null ) return
 
     if( !this._inRange( this.blocksRead - 1 ) ) {
-      if( this.blocksRead > this.currentRange.end )
+      if( this.blocksRead > this.currentRange.end ) {
+        this._verifyRange()
         this.currentRange = this.blockMap.ranges[ ++this.rangesRead ]
+      }
       return
     }
 
@@ -94,6 +149,10 @@ function FilterStream( blockMap, options ) {
     this.blocksWritten++
     this.bytesWritten += block.length
     this.position = block.position + block.length
+
+    if( this.options.verify ) {
+      this._hash.update( block )
+    }
 
     return this.push( block )
 

--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -1,6 +1,7 @@
 var stream = require( 'stream' )
 var fs = require( 'fs' )
 var inherit = require( 'bloodline' )
+var crypto = require( 'crypto' )
 
 /**
  * ReadStream
@@ -8,8 +9,9 @@ var inherit = require( 'bloodline' )
  * @memberOf BlockMap
  * @param {String} filename - image path
  * @param {BlockMap} blockMap - image's blockmap
- * @param {Object} options
- * @param {String} options.flags - fs.open() flags
+ * @param {Object} [options] - options
+ * @param {String} [options.flags='r'] - fs.open() flags
+ * @param {Boolean} [options.verify=true] - verify range checksums
  * @returns {BlockMap.ReadStream}
  */
 function ReadStream( filename, blockMap, options ) {
@@ -25,14 +27,18 @@ function ReadStream( filename, blockMap, options ) {
     throw new Error( 'Missing block map' )
   }
 
-  options = options || {}
+  /** @type {Object} options */
+  this.options = options || {}
 
-  stream.Readable.call( this, options )
+  this.options.verify = this.options.verify != null ?
+    !!this.options.verify : true
+
+  stream.Readable.call( this, this.options )
 
   /** @type {String} File path */
   this.path = filename
   /** @type {String} File open flags */
-  this.flags = options.flags || 'r'
+  this.flags = this.options.flags || 'r'
   /** @type {BlockMap} The block map */
   this.blockMap = blockMap
   /** @type {Number} Size of a mapped block in bytes */
@@ -49,6 +55,14 @@ function ReadStream( filename, blockMap, options ) {
   this.bytesRead = 0
   /** @type {Number} Current offset in bytes */
   this.position = 0
+
+  /**
+   * Hash stream to calculate range checksums
+   * @type {crypto.Hash}
+   * @private
+   */
+  this._hash = this.options.verify ?
+    crypto.createHash( this.blockMap.checksumType ) : null
 
   /**
    * Whether there's a read in progress
@@ -93,6 +107,38 @@ ReadStream.prototype = {
     })
   },
 
+  /**
+   * Verify the current range, if completed,
+   * and emit an error on mismatch
+   * @private
+   */
+  _verifyRange() {
+
+    var needsVerify = this.options.verify &&
+      this.currentRange != null &&
+      this.blockInRange >= this.rangeBlockCount
+
+    if( !needsVerify ) return
+
+    var range = this.currentRange
+    var digest = this._hash.digest( 'hex' )
+    var error = null
+
+    this._hash = crypto.createHash( this.blockMap.checksumType )
+
+    if( range.checksum !== digest ) {
+      error = new Error( 'Invalid checksum for range [' + range.start + ',' + range.end + ']' )
+      error.checksum = digest
+      error.range = range
+      this.emit( 'error', error )
+    }
+
+  },
+
+  /**
+   * Read one block from the source
+   * @private
+   */
   _readBlock() {
 
     var range = this.currentRange
@@ -122,6 +168,11 @@ ReadStream.prototype = {
       this.bytesRead += bytesRead
       this.position += bytesRead
 
+      // Feed the hash if we're verifying
+      if( this.options.verify ) {
+        this._hash.update( buffer )
+      }
+
       // Check if we should continue reading
       if( this.push( buffer ) ) {
         this._isReading = false
@@ -150,7 +201,10 @@ ReadStream.prototype = {
       return this._close()
     }
 
+    // If we're either reading the first block, or have completed a block range;
+    // verify, then switch to next range & continue block reads
     if( this.currentRange == null || this.blockInRange >= this.rangeBlockCount ) {
+      this._verifyRange()
       this.currentRange = this.blockMap.ranges[ this.rangesRead++ ]
       this.blockInRange = 0
       this._readBlock()

--- a/test/data/invalid/range/README.md
+++ b/test/data/invalid/range/README.md
@@ -1,0 +1,9 @@
+# Invalid / Range
+
+**NOTE:** All of these files have their file checksums removed,
+to avoid interference of checksum verification in testing.
+
+- `version-*.bmap`: These files an invalidated checksum for range [119-133]
+
+- `multiple-*.bmap`: These files have invalidated checksums for ranges
+  [15-18], [119-133], and [191]

--- a/test/data/invalid/range/multiple-1.2.bmap
+++ b/test/data/invalid/range/multiple-1.2.bmap
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<!-- This file has invalidated checksums for ranges [15-18], [119-133], and [191],
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.2">
+    <ImageSize> 821752 </ImageSize>
+
+    <BlockSize> 4096 </BlockSize>
+
+    <BlocksCount> 201 </BlocksCount>
+    <BlockMap>
+        <Range sha1="94789636db14cdb8929133e7b8d3a158837e2e5a"> 0-1 </Range>
+        <Range sha1="4ad09a593ed833ece30d808477cb2f43fe7e96fe"> 3-5 </Range>
+        <Range sha1="35bea6bfaa394f4cf030dc0060befed0ab04c55c"> 9-10 </Range>
+        <Range sha1="21338baaedb0976efbb075736820f6bd6ae43b97"> 12 </Range>
+        <Range sha1="X0086eaaf78f8eb52c80ea3a559be9958b4dee82"> 15-18 </Range>
+        <Range sha1="3e7c00626f9db9451fe0b55fa2a8cf2a81d9830a"> 20 </Range>
+        <Range sha1="458e9562df17d15ab3aa055ae681eec8f2d4c0fd"> 22 </Range>
+        <Range sha1="624066e4cb2838443ab2b1178bd4179d9d62acb8"> 24 </Range>
+        <Range sha1="7aa2876168020797c7060e241436c82889d66da9"> 30-32 </Range>
+        <Range sha1="5ae8333f60e55f8891e21c90e89ea603be421ca3"> 34-35 </Range>
+        <Range sha1="d5af843e9f9a1154ae610a30c71698089a298215"> 40 </Range>
+        <Range sha1="a98956e9a1801e612a1c07a0aa0f0c57be86c671"> 42-43 </Range>
+        <Range sha1="a121482d334a2bd9a42c444f99fe365ddf83a758"> 45 </Range>
+        <Range sha1="f619721549e15de1d6d5f7be85f9942140ae0d16"> 47 </Range>
+        <Range sha1="196df31f78d0e3cb623d4496e6237c4e9683cd81"> 49-50 </Range>
+        <Range sha1="f4cba9e7822dfb5206874e2a952681c53c513a71"> 52-53 </Range>
+        <Range sha1="7794743dc660f6ef29577b01af7146f6ad682a89"> 55-56 </Range>
+        <Range sha1="557fac47c5ae2476c04054b73680e531eeba116e"> 60-63 </Range>
+        <Range sha1="dba433052c7009aa4cbfdf81dabc17b285b8d087"> 65-67 </Range>
+        <Range sha1="55ab7ef8c797e942ea110aadcd22b55b19734ad3"> 70 </Range>
+        <Range sha1="2797a838edf16114b587d349da5b6c999290b02f"> 72 </Range>
+        <Range sha1="594cc8b274a0a92f2489765ca35545e1118d2375"> 78-80 </Range>
+        <Range sha1="e5f421fc2bdcdddd1f1f7081355091d5ec116930"> 82-83 </Range>
+        <Range sha1="c152f2a6e5eb08eae7122eabe8de71abb67fa810"> 85 </Range>
+        <Range sha1="67de1912c30546a2a0debca8ae41a0605a6eaa1a"> 88 </Range>
+        <Range sha1="b87c912352c16d33f056be47e26ece50375e560e"> 90-91 </Range>
+        <Range sha1="2976768755f1b5dd3a6386f8ade4887022024660"> 96 </Range>
+        <Range sha1="045ae769f1de3d99b35362b7e309609b6ff39886"> 98-105 </Range>
+        <Range sha1="dc6ba49fd6639a416c515575cd3c1a18bbbd77d7"> 111 </Range>
+        <Range sha1="b489f230fa3d578aeeb64d15d3ceba9c3f7fac18"> 114-116 </Range>
+        <Range sha1="X9645cb904ec22f017fd24a8d5a188329cca1bdf"> 119-133 </Range>
+        <Range sha1="b25d6cd7311fd4b132e085b4649ca6af663f290b"> 135 </Range>
+        <Range sha1="8cba06dbce2c88a2d8370ab28c696e5871a3e80f"> 137 </Range>
+        <Range sha1="c5143c106c7cdb1324e55b862d8f3a7c7773fbd2"> 140 </Range>
+        <Range sha1="386e2a53aff173f7c8432a33ba9f115cb0f3f2dd"> 142-144 </Range>
+        <Range sha1="9536bce6180a813bf09b555bef8cc385c2250155"> 146-147 </Range>
+        <Range sha1="0b615f57ce2368bc58a03adab323d1fc40182ada"> 150-151 </Range>
+        <Range sha1="fa2982eb55d8302d534719e2099405e3cf10ab20"> 155 </Range>
+        <Range sha1="2867488d3abd8f16805c19e0ec639aebff9ff5b2"> 157 </Range>
+        <Range sha1="98cbb098a082e8c9c42945c38f057cc911b2e892"> 159-160 </Range>
+        <Range sha1="2627075946035748c9e341adc915edfdb1a97bc8"> 163-174 </Range>
+        <Range sha1="1a34d6fc1e86e38d5e5c4e3fb50e7f9b2e07870d"> 177 </Range>
+        <Range sha1="e170e81e69f8301d331382378823b5b2a577b670"> 181-186 </Range>
+        <Range sha1="1d463c99d29fb207fc7fd36bb297218294b851af"> 188-189 </Range>
+        <Range sha1="X9652579027a70352fb8ee9ba94fe5bff486de6e"> 191 </Range>
+        <Range sha1="bee29c4d8f84c068a1be05a22aaf20c2e1f5fb92"> 193 </Range>
+        <Range sha1="959bba0c61e2e25d87af92e882d2d7d851376e72"> 195 </Range>
+        <Range sha1="dbca3770aa48e9e05629f8890d1b2330be709b8a"> 198-199 </Range>
+    </BlockMap>
+    <MappedBlocksCount> 117 </MappedBlocksCount>
+</bmap>

--- a/test/data/invalid/range/multiple-1.3.bmap
+++ b/test/data/invalid/range/multiple-1.3.bmap
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<!-- This file has invalidated checksums for ranges [15-18], [119-133], and [191],
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.3">
+    <ImageSize> 821752 </ImageSize>
+    <BlockSize> 4096 </BlockSize>
+    <BlocksCount> 201 </BlocksCount>
+    <MappedBlocksCount> 117    </MappedBlocksCount>
+    <BlockMap>
+        <Range sha1="94789636db14cdb8929133e7b8d3a158837e2e5a"> 0-1 </Range>
+        <Range sha1="4ad09a593ed833ece30d808477cb2f43fe7e96fe"> 3-5 </Range>
+        <Range sha1="35bea6bfaa394f4cf030dc0060befed0ab04c55c"> 9-10 </Range>
+        <Range sha1="21338baaedb0976efbb075736820f6bd6ae43b97"> 12 </Range>
+        <Range sha1="X0086eaaf78f8eb52c80ea3a559be9958b4dee82"> 15-18 </Range>
+        <Range sha1="3e7c00626f9db9451fe0b55fa2a8cf2a81d9830a"> 20 </Range>
+        <Range sha1="458e9562df17d15ab3aa055ae681eec8f2d4c0fd"> 22 </Range>
+        <Range sha1="624066e4cb2838443ab2b1178bd4179d9d62acb8"> 24 </Range>
+        <Range sha1="7aa2876168020797c7060e241436c82889d66da9"> 30-32 </Range>
+        <Range sha1="5ae8333f60e55f8891e21c90e89ea603be421ca3"> 34-35 </Range>
+        <Range sha1="d5af843e9f9a1154ae610a30c71698089a298215"> 40 </Range>
+        <Range sha1="a98956e9a1801e612a1c07a0aa0f0c57be86c671"> 42-43 </Range>
+        <Range sha1="a121482d334a2bd9a42c444f99fe365ddf83a758"> 45 </Range>
+        <Range sha1="f619721549e15de1d6d5f7be85f9942140ae0d16"> 47 </Range>
+        <Range sha1="196df31f78d0e3cb623d4496e6237c4e9683cd81"> 49-50 </Range>
+        <Range sha1="f4cba9e7822dfb5206874e2a952681c53c513a71"> 52-53 </Range>
+        <Range sha1="7794743dc660f6ef29577b01af7146f6ad682a89"> 55-56 </Range>
+        <Range sha1="557fac47c5ae2476c04054b73680e531eeba116e"> 60-63 </Range>
+        <Range sha1="dba433052c7009aa4cbfdf81dabc17b285b8d087"> 65-67 </Range>
+        <Range sha1="55ab7ef8c797e942ea110aadcd22b55b19734ad3"> 70 </Range>
+        <Range sha1="2797a838edf16114b587d349da5b6c999290b02f"> 72 </Range>
+        <Range sha1="594cc8b274a0a92f2489765ca35545e1118d2375"> 78-80 </Range>
+        <Range sha1="e5f421fc2bdcdddd1f1f7081355091d5ec116930"> 82-83 </Range>
+        <Range sha1="c152f2a6e5eb08eae7122eabe8de71abb67fa810"> 85 </Range>
+        <Range sha1="67de1912c30546a2a0debca8ae41a0605a6eaa1a"> 88 </Range>
+        <Range sha1="b87c912352c16d33f056be47e26ece50375e560e"> 90-91 </Range>
+        <Range sha1="2976768755f1b5dd3a6386f8ade4887022024660"> 96 </Range>
+        <Range sha1="045ae769f1de3d99b35362b7e309609b6ff39886"> 98-105 </Range>
+        <Range sha1="dc6ba49fd6639a416c515575cd3c1a18bbbd77d7"> 111 </Range>
+        <Range sha1="b489f230fa3d578aeeb64d15d3ceba9c3f7fac18"> 114-116 </Range>
+        <Range sha1="X9645cb904ec22f017fd24a8d5a188329cca1bdf"> 119-133 </Range>
+        <Range sha1="b25d6cd7311fd4b132e085b4649ca6af663f290b"> 135 </Range>
+        <Range sha1="8cba06dbce2c88a2d8370ab28c696e5871a3e80f"> 137 </Range>
+        <Range sha1="c5143c106c7cdb1324e55b862d8f3a7c7773fbd2"> 140 </Range>
+        <Range sha1="386e2a53aff173f7c8432a33ba9f115cb0f3f2dd"> 142-144 </Range>
+        <Range sha1="9536bce6180a813bf09b555bef8cc385c2250155"> 146-147 </Range>
+        <Range sha1="0b615f57ce2368bc58a03adab323d1fc40182ada"> 150-151 </Range>
+        <Range sha1="fa2982eb55d8302d534719e2099405e3cf10ab20"> 155 </Range>
+        <Range sha1="2867488d3abd8f16805c19e0ec639aebff9ff5b2"> 157 </Range>
+        <Range sha1="98cbb098a082e8c9c42945c38f057cc911b2e892"> 159-160 </Range>
+        <Range sha1="2627075946035748c9e341adc915edfdb1a97bc8"> 163-174 </Range>
+        <Range sha1="1a34d6fc1e86e38d5e5c4e3fb50e7f9b2e07870d"> 177 </Range>
+        <Range sha1="e170e81e69f8301d331382378823b5b2a577b670"> 181-186 </Range>
+        <Range sha1="1d463c99d29fb207fc7fd36bb297218294b851af"> 188-189 </Range>
+        <Range sha1="X9652579027a70352fb8ee9ba94fe5bff486de6e"> 191 </Range>
+        <Range sha1="bee29c4d8f84c068a1be05a22aaf20c2e1f5fb92"> 193 </Range>
+        <Range sha1="959bba0c61e2e25d87af92e882d2d7d851376e72"> 195 </Range>
+        <Range sha1="dbca3770aa48e9e05629f8890d1b2330be709b8a"> 198-199 </Range>
+    </BlockMap>
+</bmap>

--- a/test/data/invalid/range/multiple-1.4.bmap
+++ b/test/data/invalid/range/multiple-1.4.bmap
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<!-- This file has invalidated checksums for ranges [15-18], [119-133], and [191],
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.4">
+    <ImageSize> 821752 </ImageSize>
+    <BlockSize> 4096 </BlockSize>
+    <BlocksCount> 201 </BlocksCount>
+    <MappedBlocksCount> 117    </MappedBlocksCount>
+    <ChecksumType> sha256 </ChecksumType>
+    <BlockMap>
+        <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500"> 0-1 </Range>
+        <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2"> 3-5 </Range>
+        <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66"> 9-10 </Range>
+        <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196"> 12 </Range>
+        <Range chksum="X9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a"> 15-18 </Range>
+        <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a"> 20 </Range>
+        <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6"> 22 </Range>
+        <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371"> 24 </Range>
+        <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876"> 30-32 </Range>
+        <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6"> 34-35 </Range>
+        <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae"> 40 </Range>
+        <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea"> 42-43 </Range>
+        <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195"> 45 </Range>
+        <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970"> 47 </Range>
+        <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1"> 49-50 </Range>
+        <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4"> 52-53 </Range>
+        <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28"> 55-56 </Range>
+        <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336"> 60-63 </Range>
+        <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6"> 65-67 </Range>
+        <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f"> 70 </Range>
+        <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779"> 72 </Range>
+        <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090"> 78-80 </Range>
+        <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f"> 82-83 </Range>
+        <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654"> 85 </Range>
+        <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0"> 88 </Range>
+        <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6"> 90-91 </Range>
+        <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa"> 96 </Range>
+        <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017"> 98-105 </Range>
+        <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6"> 111 </Range>
+        <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930"> 114-116 </Range>
+        <Range chksum="X83e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399"> 119-133 </Range>
+        <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec"> 135 </Range>
+        <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a"> 137 </Range>
+        <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5"> 140 </Range>
+        <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0"> 142-144 </Range>
+        <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37"> 146-147 </Range>
+        <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913"> 150-151 </Range>
+        <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178"> 155 </Range>
+        <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820"> 157 </Range>
+        <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370"> 159-160 </Range>
+        <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094"> 163-174 </Range>
+        <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98"> 177 </Range>
+        <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9"> 181-186 </Range>
+        <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258"> 188-189 </Range>
+        <Range chksum="X29690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384"> 191 </Range>
+        <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965"> 193 </Range>
+        <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900"> 195 </Range>
+        <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c"> 198-199 </Range>
+    </BlockMap>
+</bmap>

--- a/test/data/invalid/range/multiple-2.0.bmap
+++ b/test/data/invalid/range/multiple-2.0.bmap
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<!-- This file has invalidated checksums for ranges [15-18], [119-133], and [191],
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="2.0">
+    <ImageSize> 821752 </ImageSize>
+    <BlockSize> 4096 </BlockSize>
+    <BlocksCount> 201 </BlocksCount>
+    <MappedBlocksCount> 117    </MappedBlocksCount>
+    <ChecksumType> sha256 </ChecksumType>
+    <BlockMap>
+        <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500"> 0-1 </Range>
+        <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2"> 3-5 </Range>
+        <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66"> 9-10 </Range>
+        <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196"> 12 </Range>
+        <Range chksum="X9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a"> 15-18 </Range>
+        <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a"> 20 </Range>
+        <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6"> 22 </Range>
+        <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371"> 24 </Range>
+        <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876"> 30-32 </Range>
+        <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6"> 34-35 </Range>
+        <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae"> 40 </Range>
+        <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea"> 42-43 </Range>
+        <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195"> 45 </Range>
+        <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970"> 47 </Range>
+        <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1"> 49-50 </Range>
+        <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4"> 52-53 </Range>
+        <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28"> 55-56 </Range>
+        <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336"> 60-63 </Range>
+        <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6"> 65-67 </Range>
+        <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f"> 70 </Range>
+        <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779"> 72 </Range>
+        <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090"> 78-80 </Range>
+        <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f"> 82-83 </Range>
+        <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654"> 85 </Range>
+        <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0"> 88 </Range>
+        <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6"> 90-91 </Range>
+        <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa"> 96 </Range>
+        <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017"> 98-105 </Range>
+        <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6"> 111 </Range>
+        <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930"> 114-116 </Range>
+        <Range chksum="X83e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399"> 119-133 </Range>
+        <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec"> 135 </Range>
+        <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a"> 137 </Range>
+        <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5"> 140 </Range>
+        <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0"> 142-144 </Range>
+        <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37"> 146-147 </Range>
+        <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913"> 150-151 </Range>
+        <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178"> 155 </Range>
+        <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820"> 157 </Range>
+        <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370"> 159-160 </Range>
+        <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094"> 163-174 </Range>
+        <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98"> 177 </Range>
+        <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9"> 181-186 </Range>
+        <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258"> 188-189 </Range>
+        <Range chksum="X29690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384"> 191 </Range>
+        <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965"> 193 </Range>
+        <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900"> 195 </Range>
+        <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c"> 198-199 </Range>
+    </BlockMap>
+</bmap>

--- a/test/data/invalid/range/version-1.2.bmap
+++ b/test/data/invalid/range/version-1.2.bmap
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<!-- This file has range[119-133] checksum invalidated for testing purposes,
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.2">
+  <ImageSize>821752 </ImageSize>
+  <BlockSize>4096 </BlockSize>
+  <BlocksCount>201 </BlocksCount>
+  <BlockMap>
+    <Range sha1="94789636db14cdb8929133e7b8d3a158837e2e5a">0-1 </Range>
+    <Range sha1="4ad09a593ed833ece30d808477cb2f43fe7e96fe">3-5 </Range>
+    <Range sha1="35bea6bfaa394f4cf030dc0060befed0ab04c55c">9-10 </Range>
+    <Range sha1="21338baaedb0976efbb075736820f6bd6ae43b97">12 </Range>
+    <Range sha1="80086eaaf78f8eb52c80ea3a559be9958b4dee82">15-18 </Range>
+    <Range sha1="3e7c00626f9db9451fe0b55fa2a8cf2a81d9830a">20 </Range>
+    <Range sha1="458e9562df17d15ab3aa055ae681eec8f2d4c0fd">22 </Range>
+    <Range sha1="624066e4cb2838443ab2b1178bd4179d9d62acb8">24 </Range>
+    <Range sha1="7aa2876168020797c7060e241436c82889d66da9">30-32 </Range>
+    <Range sha1="5ae8333f60e55f8891e21c90e89ea603be421ca3">34-35 </Range>
+    <Range sha1="d5af843e9f9a1154ae610a30c71698089a298215">40 </Range>
+    <Range sha1="a98956e9a1801e612a1c07a0aa0f0c57be86c671">42-43 </Range>
+    <Range sha1="a121482d334a2bd9a42c444f99fe365ddf83a758">45 </Range>
+    <Range sha1="f619721549e15de1d6d5f7be85f9942140ae0d16">47 </Range>
+    <Range sha1="196df31f78d0e3cb623d4496e6237c4e9683cd81">49-50 </Range>
+    <Range sha1="f4cba9e7822dfb5206874e2a952681c53c513a71">52-53 </Range>
+    <Range sha1="7794743dc660f6ef29577b01af7146f6ad682a89">55-56 </Range>
+    <Range sha1="557fac47c5ae2476c04054b73680e531eeba116e">60-63 </Range>
+    <Range sha1="dba433052c7009aa4cbfdf81dabc17b285b8d087">65-67 </Range>
+    <Range sha1="55ab7ef8c797e942ea110aadcd22b55b19734ad3">70 </Range>
+    <Range sha1="2797a838edf16114b587d349da5b6c999290b02f">72 </Range>
+    <Range sha1="594cc8b274a0a92f2489765ca35545e1118d2375">78-80 </Range>
+    <Range sha1="e5f421fc2bdcdddd1f1f7081355091d5ec116930">82-83 </Range>
+    <Range sha1="c152f2a6e5eb08eae7122eabe8de71abb67fa810">85 </Range>
+    <Range sha1="67de1912c30546a2a0debca8ae41a0605a6eaa1a">88 </Range>
+    <Range sha1="b87c912352c16d33f056be47e26ece50375e560e">90-91 </Range>
+    <Range sha1="2976768755f1b5dd3a6386f8ade4887022024660">96 </Range>
+    <Range sha1="045ae769f1de3d99b35362b7e309609b6ff39886">98-105 </Range>
+    <Range sha1="dc6ba49fd6639a416c515575cd3c1a18bbbd77d7">111 </Range>
+    <Range sha1="b489f230fa3d578aeeb64d15d3ceba9c3f7fac18">114-116 </Range>
+    <Range sha1="X9645cb904ec22f017fd24a8d5a188329cca1bdf">119-133 </Range>
+    <Range sha1="b25d6cd7311fd4b132e085b4649ca6af663f290b">135 </Range>
+    <Range sha1="8cba06dbce2c88a2d8370ab28c696e5871a3e80f">137 </Range>
+    <Range sha1="c5143c106c7cdb1324e55b862d8f3a7c7773fbd2">140 </Range>
+    <Range sha1="386e2a53aff173f7c8432a33ba9f115cb0f3f2dd">142-144 </Range>
+    <Range sha1="9536bce6180a813bf09b555bef8cc385c2250155">146-147 </Range>
+    <Range sha1="0b615f57ce2368bc58a03adab323d1fc40182ada">150-151 </Range>
+    <Range sha1="fa2982eb55d8302d534719e2099405e3cf10ab20">155 </Range>
+    <Range sha1="2867488d3abd8f16805c19e0ec639aebff9ff5b2">157 </Range>
+    <Range sha1="98cbb098a082e8c9c42945c38f057cc911b2e892">159-160 </Range>
+    <Range sha1="2627075946035748c9e341adc915edfdb1a97bc8">163-174 </Range>
+    <Range sha1="1a34d6fc1e86e38d5e5c4e3fb50e7f9b2e07870d">177 </Range>
+    <Range sha1="e170e81e69f8301d331382378823b5b2a577b670">181-186 </Range>
+    <Range sha1="1d463c99d29fb207fc7fd36bb297218294b851af">188-189 </Range>
+    <Range sha1="39652579027a70352fb8ee9ba94fe5bff486de6e">191 </Range>
+    <Range sha1="bee29c4d8f84c068a1be05a22aaf20c2e1f5fb92">193 </Range>
+    <Range sha1="959bba0c61e2e25d87af92e882d2d7d851376e72">195 </Range>
+    <Range sha1="dbca3770aa48e9e05629f8890d1b2330be709b8a">198-199 </Range>
+  </BlockMap>
+  <MappedBlocksCount>117 </MappedBlocksCount>
+</bmap>

--- a/test/data/invalid/range/version-1.3.bmap
+++ b/test/data/invalid/range/version-1.3.bmap
@@ -1,0 +1,59 @@
+<?xml version="1.0" ?>
+<!-- This file has range[119-133] checksum invalidated for testing purposes,
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.3">
+  <ImageSize>821752 </ImageSize>
+  <BlockSize>4096 </BlockSize>
+  <BlocksCount>201 </BlocksCount>
+  <MappedBlocksCount>117    </MappedBlocksCount>
+  <BlockMap>
+    <Range sha1="94789636db14cdb8929133e7b8d3a158837e2e5a">0-1 </Range>
+    <Range sha1="4ad09a593ed833ece30d808477cb2f43fe7e96fe">3-5 </Range>
+    <Range sha1="35bea6bfaa394f4cf030dc0060befed0ab04c55c">9-10 </Range>
+    <Range sha1="21338baaedb0976efbb075736820f6bd6ae43b97">12 </Range>
+    <Range sha1="80086eaaf78f8eb52c80ea3a559be9958b4dee82">15-18 </Range>
+    <Range sha1="3e7c00626f9db9451fe0b55fa2a8cf2a81d9830a">20 </Range>
+    <Range sha1="458e9562df17d15ab3aa055ae681eec8f2d4c0fd">22 </Range>
+    <Range sha1="624066e4cb2838443ab2b1178bd4179d9d62acb8">24 </Range>
+    <Range sha1="7aa2876168020797c7060e241436c82889d66da9">30-32 </Range>
+    <Range sha1="5ae8333f60e55f8891e21c90e89ea603be421ca3">34-35 </Range>
+    <Range sha1="d5af843e9f9a1154ae610a30c71698089a298215">40 </Range>
+    <Range sha1="a98956e9a1801e612a1c07a0aa0f0c57be86c671">42-43 </Range>
+    <Range sha1="a121482d334a2bd9a42c444f99fe365ddf83a758">45 </Range>
+    <Range sha1="f619721549e15de1d6d5f7be85f9942140ae0d16">47 </Range>
+    <Range sha1="196df31f78d0e3cb623d4496e6237c4e9683cd81">49-50 </Range>
+    <Range sha1="f4cba9e7822dfb5206874e2a952681c53c513a71">52-53 </Range>
+    <Range sha1="7794743dc660f6ef29577b01af7146f6ad682a89">55-56 </Range>
+    <Range sha1="557fac47c5ae2476c04054b73680e531eeba116e">60-63 </Range>
+    <Range sha1="dba433052c7009aa4cbfdf81dabc17b285b8d087">65-67 </Range>
+    <Range sha1="55ab7ef8c797e942ea110aadcd22b55b19734ad3">70 </Range>
+    <Range sha1="2797a838edf16114b587d349da5b6c999290b02f">72 </Range>
+    <Range sha1="594cc8b274a0a92f2489765ca35545e1118d2375">78-80 </Range>
+    <Range sha1="e5f421fc2bdcdddd1f1f7081355091d5ec116930">82-83 </Range>
+    <Range sha1="c152f2a6e5eb08eae7122eabe8de71abb67fa810">85 </Range>
+    <Range sha1="67de1912c30546a2a0debca8ae41a0605a6eaa1a">88 </Range>
+    <Range sha1="b87c912352c16d33f056be47e26ece50375e560e">90-91 </Range>
+    <Range sha1="2976768755f1b5dd3a6386f8ade4887022024660">96 </Range>
+    <Range sha1="045ae769f1de3d99b35362b7e309609b6ff39886">98-105 </Range>
+    <Range sha1="dc6ba49fd6639a416c515575cd3c1a18bbbd77d7">111 </Range>
+    <Range sha1="b489f230fa3d578aeeb64d15d3ceba9c3f7fac18">114-116 </Range>
+    <Range sha1="X9645cb904ec22f017fd24a8d5a188329cca1bdf">119-133 </Range>
+    <Range sha1="b25d6cd7311fd4b132e085b4649ca6af663f290b">135 </Range>
+    <Range sha1="8cba06dbce2c88a2d8370ab28c696e5871a3e80f">137 </Range>
+    <Range sha1="c5143c106c7cdb1324e55b862d8f3a7c7773fbd2">140 </Range>
+    <Range sha1="386e2a53aff173f7c8432a33ba9f115cb0f3f2dd">142-144 </Range>
+    <Range sha1="9536bce6180a813bf09b555bef8cc385c2250155">146-147 </Range>
+    <Range sha1="0b615f57ce2368bc58a03adab323d1fc40182ada">150-151 </Range>
+    <Range sha1="fa2982eb55d8302d534719e2099405e3cf10ab20">155 </Range>
+    <Range sha1="2867488d3abd8f16805c19e0ec639aebff9ff5b2">157 </Range>
+    <Range sha1="98cbb098a082e8c9c42945c38f057cc911b2e892">159-160 </Range>
+    <Range sha1="2627075946035748c9e341adc915edfdb1a97bc8">163-174 </Range>
+    <Range sha1="1a34d6fc1e86e38d5e5c4e3fb50e7f9b2e07870d">177 </Range>
+    <Range sha1="e170e81e69f8301d331382378823b5b2a577b670">181-186 </Range>
+    <Range sha1="1d463c99d29fb207fc7fd36bb297218294b851af">188-189 </Range>
+    <Range sha1="39652579027a70352fb8ee9ba94fe5bff486de6e">191 </Range>
+    <Range sha1="bee29c4d8f84c068a1be05a22aaf20c2e1f5fb92">193 </Range>
+    <Range sha1="959bba0c61e2e25d87af92e882d2d7d851376e72">195 </Range>
+    <Range sha1="dbca3770aa48e9e05629f8890d1b2330be709b8a">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/data/invalid/range/version-1.4.bmap
+++ b/test/data/invalid/range/version-1.4.bmap
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<!-- This file has range[119-133] checksum invalidated for testing purposes,
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="1.4">
+  <ImageSize>821752 </ImageSize>
+  <BlockSize>4096 </BlockSize>
+  <BlocksCount>201 </BlocksCount>
+  <MappedBlocksCount>117    </MappedBlocksCount>
+  <ChecksumType>sha256 </ChecksumType>
+  <BlockMap>
+    <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500">0-1 </Range>
+    <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2">3-5 </Range>
+    <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66">9-10 </Range>
+    <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196">12 </Range>
+    <Range chksum="f9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a">15-18 </Range>
+    <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a">20 </Range>
+    <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6">22 </Range>
+    <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371">24 </Range>
+    <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876">30-32 </Range>
+    <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6">34-35 </Range>
+    <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae">40 </Range>
+    <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea">42-43 </Range>
+    <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195">45 </Range>
+    <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970">47 </Range>
+    <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1">49-50 </Range>
+    <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4">52-53 </Range>
+    <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28">55-56 </Range>
+    <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336">60-63 </Range>
+    <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6">65-67 </Range>
+    <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f">70 </Range>
+    <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779">72 </Range>
+    <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090">78-80 </Range>
+    <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f">82-83 </Range>
+    <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654">85 </Range>
+    <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0">88 </Range>
+    <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6">90-91 </Range>
+    <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa">96 </Range>
+    <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017">98-105 </Range>
+    <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6">111 </Range>
+    <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930">114-116 </Range>
+    <Range chksum="X83e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399">119-133 </Range>
+    <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec">135 </Range>
+    <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a">137 </Range>
+    <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5">140 </Range>
+    <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0">142-144 </Range>
+    <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37">146-147 </Range>
+    <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913">150-151 </Range>
+    <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178">155 </Range>
+    <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820">157 </Range>
+    <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370">159-160 </Range>
+    <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094">163-174 </Range>
+    <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98">177 </Range>
+    <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9">181-186 </Range>
+    <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258">188-189 </Range>
+    <Range chksum="229690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384">191 </Range>
+    <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965">193 </Range>
+    <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900">195 </Range>
+    <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/data/invalid/range/version-2.0.bmap
+++ b/test/data/invalid/range/version-2.0.bmap
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<!-- This file has range[119-133] checksum invalidated for testing purposes,
+     and thus has the BmapFileChecksum removed to not interfere in parsing -->
+<bmap version="2.0">
+  <ImageSize>821752 </ImageSize>
+  <BlockSize>4096 </BlockSize>
+  <BlocksCount>201 </BlocksCount>
+  <MappedBlocksCount>117    </MappedBlocksCount>
+  <ChecksumType>sha256 </ChecksumType>
+  <BlockMap>
+    <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500">0-1 </Range>
+    <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2">3-5 </Range>
+    <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66">9-10 </Range>
+    <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196">12 </Range>
+    <Range chksum="f9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a">15-18 </Range>
+    <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a">20 </Range>
+    <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6">22 </Range>
+    <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371">24 </Range>
+    <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876">30-32 </Range>
+    <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6">34-35 </Range>
+    <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae">40 </Range>
+    <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea">42-43 </Range>
+    <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195">45 </Range>
+    <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970">47 </Range>
+    <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1">49-50 </Range>
+    <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4">52-53 </Range>
+    <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28">55-56 </Range>
+    <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336">60-63 </Range>
+    <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6">65-67 </Range>
+    <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f">70 </Range>
+    <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779">72 </Range>
+    <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090">78-80 </Range>
+    <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f">82-83 </Range>
+    <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654">85 </Range>
+    <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0">88 </Range>
+    <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6">90-91 </Range>
+    <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa">96 </Range>
+    <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017">98-105 </Range>
+    <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6">111 </Range>
+    <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930">114-116 </Range>
+    <Range chksum="X83e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399">119-133 </Range>
+    <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec">135 </Range>
+    <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a">137 </Range>
+    <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5">140 </Range>
+    <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0">142-144 </Range>
+    <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37">146-147 </Range>
+    <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913">150-151 </Range>
+    <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178">155 </Range>
+    <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820">157 </Range>
+    <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370">159-160 </Range>
+    <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094">163-174 </Range>
+    <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98">177 </Range>
+    <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9">181-186 </Range>
+    <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258">188-189 </Range>
+    <Range chksum="229690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384">191 </Range>
+    <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965">193 </Range>
+    <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900">195 </Range>
+    <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/filter-stream.js
+++ b/test/filter-stream.js
@@ -30,4 +30,82 @@ describe( 'BlockMap.FilterStream', function() {
 
   })
 
+  context( 'disabled verification', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: ignore invalid ranges`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/multiple-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = fs.createReadStream( filename )
+        var transform = new BlockMap.FilterStream( blockMap, { verify: false })
+
+        readStream.pipe( transform ).resume()
+          .on( 'error', done )
+          .on( 'end', done )
+
+      })
+    })
+  })
+
+  context( 'single invalid range', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: detect an invalid range`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/version-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = fs.createReadStream( filename )
+        var transform = new BlockMap.FilterStream( blockMap )
+
+        readStream.pipe( transform ).resume()
+          .on( 'error', function( error ) {
+            assert.ok( error instanceof Error, 'error not instance of Error' )
+            // The calculated checksum
+            assert.ok( error.checksum, 'missing checksum' )
+            // The faulty range's data
+            assert.strictEqual( error.range.start, 119, 'incorrect range start' )
+            assert.strictEqual( error.range.end, 133, 'incorrect range end' )
+            assert.ok( error.range.checksum, 'missing "faulty" checksum' )
+            done()
+          })
+          .on( 'end', function() {
+            done( new Error( 'Did not detect faulty range checksum' ) )
+          })
+
+      })
+    })
+  })
+
+  context( 'multiple invalid ranges', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: detect invalid ranges`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/multiple-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = fs.createReadStream( filename )
+        var transform = new BlockMap.FilterStream( blockMap, { verify: true })
+        var hadErrors = 0
+
+        readStream.pipe( transform ).resume()
+          .on( 'error', function( error ) {
+            assert.ok( error instanceof Error, 'error not instance of Error' )
+            assert.ok( /^Invalid checksum for range/.test( error.message ) )
+            hadErrors++
+            // NOTE: Because readable streams unpipe themselves if the dest
+            // experiences an error, and there's no way to turn that off,
+            // we have to re-pipe in the error handler to continue reading.
+            // For details, see https://github.com/nodejs/node/blob/master/lib/_stream_readable.js#L572-L583
+            readStream.pipe( transform )
+          })
+          .on( 'end', function() {
+            assert.strictEqual( hadErrors, 3, 'not enough errors' )
+            done()
+          })
+
+      })
+    })
+  })
+
 })

--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -29,4 +29,77 @@ describe( 'BlockMap.ReadStream', function() {
 
   })
 
+  context( 'disabled verification', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: ignore invalid ranges`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/multiple-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = new BlockMap.ReadStream( filename, blockMap, { verify: false })
+
+        readStream.resume()
+          .on( 'error', done )
+          .on( 'end', done )
+
+      })
+    })
+  })
+
+  context( 'single invalid range', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: detect an invalid range`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/version-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = new BlockMap.ReadStream( filename, blockMap )
+        var hadError = false
+
+        readStream.resume()
+          .on( 'error', function( error ) {
+            assert.ok( error instanceof Error, 'error not instance of Error' )
+            // The calculated checksum
+            assert.ok( error.checksum, 'missing checksum' )
+            // The faulty range's data
+            assert.strictEqual( error.range.start, 119, 'incorrect range start' )
+            assert.strictEqual( error.range.end, 133, 'incorrect range end' )
+            assert.ok( error.range.checksum, 'missing "faulty" checksum' )
+            hadError = true
+          })
+          .on( 'end', function() {
+            var error = hadError === false ?
+              new Error( 'Did not detect faulty range checksum' ) : null
+            done( error )
+          })
+
+      })
+    })
+  })
+
+  context( 'multiple invalid ranges', function() {
+    BlockMap.versions.forEach( function( v ) {
+      it( `v${v}: detect invalid ranges`, function( done ) {
+
+        var filename = path.join( __dirname, '/data/bmap.img' )
+        var bmapFile = path.join( __dirname, `/data/invalid/range/multiple-${v}.bmap` )
+        var blockMap = BlockMap.parse( fs.readFileSync( bmapFile, 'utf8' ) )
+        var readStream = new BlockMap.ReadStream( filename, blockMap, { verify: true })
+        var hadErrors = 0
+
+        readStream.resume()
+          .on( 'error', function( error ) {
+            assert.ok( error instanceof Error, 'error not instance of Error' )
+            assert.ok( /^Invalid checksum for range/.test( error.message ) )
+            hadErrors++
+          })
+          .on( 'end', function() {
+            assert.strictEqual( hadErrors, 3, 'not enough errors' )
+            done()
+          })
+
+      })
+    })
+  })
+
 })


### PR DESCRIPTION
Connects to #6 

This adds block range checksum calculation and verification to `BlockMap.ReadStream()` and `BlockMap.FilterStream()`. Upon encountering a read / write of a range with a checksum mismatch an `error` event will be emitted, where the error will not end the stream, and if handled via an event handler can occur multiple times.

With this we can detect corrupt source images, or verify an already flashed image by simply reading it back through a `BlockMap.ReadStream()` with verification enabled.

Verification is enabled by default, but can be disabled by passing `{ verify: false }` in the options.