### PR TITLE
Implement bmap file checksum verification

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -11,9 +11,10 @@
         * [.blockSize](#BlockMap+blockSize) : <code>Number</code>
         * [.blockCount](#BlockMap+blockCount) : <code>Number</code>
         * [.mappedBlockCount](#BlockMap+mappedBlockCount) : <code>Number</code>
+        * [.checksum](#BlockMap+checksum) : <code>String</code>
         * [.checksumType](#BlockMap+checksumType) : <code>Number</code>
         * [.ranges](#BlockMap+ranges) : <code>Number</code>
-        * [.parse(value)](#BlockMap+parse) ⇒ <code>[BlockMap](#BlockMap)</code>
+        * [.parse(value, [options])](#BlockMap+parse) ⇒ <code>[BlockMap](#BlockMap)</code>
     * _static_
         * [.FilterStream](#BlockMap.FilterStream)
             * [new FilterStream(blockMap, options)](#new_BlockMap.FilterStream_new)
@@ -44,7 +45,7 @@
         * [.create(options)](#BlockMap.create) ⇒ <code>[BlockMap](#BlockMap)</code>
         * [.fromJSON(data)](#BlockMap.fromJSON) ⇒ <code>[BlockMap](#BlockMap)</code>
         * [.createReadStream(filename, blockMap, options)](#BlockMap.createReadStream) ⇒ <code>[ReadStream](#BlockMap.ReadStream)</code>
-        * [.parse(value, blockMap)](#BlockMap.parse) ⇒ <code>[BlockMap](#BlockMap)</code>
+        * [.parse(value, [blockMap], [options])](#BlockMap.parse) ⇒ <code>[BlockMap](#BlockMap)</code>
         * [.stringify(blockMap, [options])](#BlockMap.stringify) ⇒ <code>String</code>
 
 
@@ -107,6 +108,15 @@ number of mapped blocks
 
 -
 
+<a name="BlockMap+checksum"></a>
+
+### blockMap.checksum : <code>String</code>
+bmap file checksum
+
+**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+
+-
+
 <a name="BlockMap+checksumType"></a>
 
 ### blockMap.checksumType : <code>Number</code>
@@ -127,13 +137,15 @@ block ranges
 
 <a name="BlockMap+parse"></a>
 
-### blockMap.parse(value) ⇒ <code>[BlockMap](#BlockMap)</code>
+### blockMap.parse(value, [options]) ⇒ <code>[BlockMap](#BlockMap)</code>
 Parse a .bmap formatted input
 
 **Kind**: instance method of <code>[BlockMap](#BlockMap)</code>  
 **Params**
 
 - value <code>String</code> | <code>Buffer</code>
+- [options] <code>Object</code> - options
+    - [.verify] <code>Boolean</code> <code> = true</code> - options
 
 
 -
@@ -459,14 +471,15 @@ Create a ReadStream for an image with a block map
 
 <a name="BlockMap.parse"></a>
 
-### BlockMap.parse(value, blockMap) ⇒ <code>[BlockMap](#BlockMap)</code>
+### BlockMap.parse(value, [blockMap], [options]) ⇒ <code>[BlockMap](#BlockMap)</code>
 Parse a .bmap file
 
 **Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
 **Params**
 
-- value <code>String</code> | <code>Buffer</code>
-- blockMap <code>[BlockMap](#BlockMap)</code>
+- value <code>String</code> | <code>Buffer</code> - input
+- [blockMap] <code>[BlockMap](#BlockMap)</code> - BlockMap instance to populate
+- [options] <code>Objects</code> - options
 
 
 -

--- a/lib/blockmap.js
+++ b/lib/blockmap.js
@@ -21,6 +21,8 @@ function BlockMap( options ) {
   this.blockCount = options.blockCount || 0
   /** @type {Number} number of mapped blocks */
   this.mappedBlockCount = options.mappedBlockCount || 0
+  /** @type {String} bmap file checksum */
+  this.checksum = options.checksum || null
   /** @type {Number} checksum algorithm */
   this.checksumType = options.checksumType || 'sha256'
   /** @type {Number} block ranges */
@@ -100,10 +102,12 @@ BlockMap.prototype = {
   /**
    * Parse a .bmap formatted input
    * @param {String|Buffer} value
+   * @param {Object} [options] - options
+   * @param {Boolean} [options.verify=true] - options
    * @returns {BlockMap}
    */
-  parse: function( value ) {
-    BlockMap.parse( value, this )
+  parse: function( value, options ) {
+    BlockMap.parse( value, this, options )
     return this
   },
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,6 @@
 var BlockMap = require( './blockmap' )
 var htmlparser = require( 'htmlparser2' )
+var crypto = require( 'crypto' )
 
 /**
  * Get the first tag of given name from a collection of nodes
@@ -70,15 +71,43 @@ function getRanges( map ) {
 }
 
 /**
+ * Zero out the file checksum field for checksum calculation
+ * @private
+ * @param {String} value - input
+ * @returns {String} maskedValue
+ */
+function maskChecksum( value ) {
+
+  var pattern = /BmapFileChecksum/.test( value ) ?
+    /(<BmapFileChecksum>\s*)([a-z0-9]+)(\s*<\/BmapFileChecksum>)/i :
+    /(<BmapFileSHA1>\s*)([a-z0-9]+)(\s*<\/BmapFileSHA1>)/i
+
+  return value.replace( pattern, function( match, start, checksum, end ) {
+    return start + checksum.replace( /./g, '0' ) + end
+  })
+
+}
+
+/**
  * Parse a .bmap file
  * @memberOf BlockMap
- * @param {String|Buffer} value
- * @param {BlockMap} blockMap
+ * @param {String|Buffer} value - input
+ * @param {BlockMap} [blockMap] - BlockMap instance to populate
+ * @param {Objects} [options] - options
  * @return {BlockMap}
  */
-function parse( value, blockMap ) {
+function parse( value, blockMap, options ) {
+
+  if( !(blockMap instanceof BlockMap) ) {
+    options = blockMap
+    blockMap = null
+  }
 
   blockMap = blockMap || new BlockMap()
+
+  options = options || {}
+  options.verify = options.verify != null ?
+    !!options.verify : true
 
   var handler = new htmlparser.DomHandler({
     normalizeWhitespace: true,
@@ -106,11 +135,22 @@ function parse( value, blockMap ) {
   blockMap.blockSize = +textContent( 'BlockSize', bmap.children )
   blockMap.blockCount = +textContent( 'BlocksCount', bmap.children )
   blockMap.mappedBlockCount = +textContent( 'MappedBlocksCount', bmap.children )
+  blockMap.checksum = textContent( 'BmapFileChecksum', bmap.children ) ||
+    textContent( 'BmapFileSHA1', bmap.children ) || null
   blockMap.checksumType = textContent( 'ChecksumType', bmap.children ) || 'sha1'
 
   var map = firstChild( 'BlockMap', bmap.children )
   if( map && map.children ) {
     blockMap.ranges = getRanges( map )
+  }
+
+  if( options.verify && blockMap.checksum != null ) {
+    var file = maskChecksum( value.toString() )
+    var digest = crypto.createHash( blockMap.checksumType )
+      .update( file ).digest( 'hex' )
+    if( blockMap.checksum !== digest ) {
+      throw new Error( 'File checksum mismatch:\n' + blockMap.checksum + ' != \n' + digest )
+    }
   }
 
   return blockMap

--- a/test/data/invalid/file-checksum/README.md
+++ b/test/data/invalid/file-checksum/README.md
@@ -1,0 +1,6 @@
+# Invalid / File-Checksum
+
+These files have extra whitespace and comments removed
+to invalidate the file checksum for testing
+
+**NOTE:** Version 1.2 has no support for file checksums

--- a/test/data/invalid/file-checksum/version-1.3.bmap
+++ b/test/data/invalid/file-checksum/version-1.3.bmap
@@ -1,0 +1,60 @@
+<?xml version="1.0" ?>
+<!-- This file has extra whitespace and comments removed
+     to invalidate the BmapFileChecksum for testing -->
+<bmap version="1.3">
+  <ImageSize>821752 </ImageSize>
+  <BlockSize>4096 </BlockSize>
+  <BlocksCount>201 </BlocksCount>
+  <MappedBlocksCount>117    </MappedBlocksCount>
+  <BmapFileSHA1>e235f7cd0c6b8c07a2e6f2538510fb763e7790a6 </BmapFileSHA1>
+  <BlockMap>
+    <Range sha1="94789636db14cdb8929133e7b8d3a158837e2e5a">0-1 </Range>
+    <Range sha1="4ad09a593ed833ece30d808477cb2f43fe7e96fe">3-5 </Range>
+    <Range sha1="35bea6bfaa394f4cf030dc0060befed0ab04c55c">9-10 </Range>
+    <Range sha1="21338baaedb0976efbb075736820f6bd6ae43b97">12 </Range>
+    <Range sha1="80086eaaf78f8eb52c80ea3a559be9958b4dee82">15-18 </Range>
+    <Range sha1="3e7c00626f9db9451fe0b55fa2a8cf2a81d9830a">20 </Range>
+    <Range sha1="458e9562df17d15ab3aa055ae681eec8f2d4c0fd">22 </Range>
+    <Range sha1="624066e4cb2838443ab2b1178bd4179d9d62acb8">24 </Range>
+    <Range sha1="7aa2876168020797c7060e241436c82889d66da9">30-32 </Range>
+    <Range sha1="5ae8333f60e55f8891e21c90e89ea603be421ca3">34-35 </Range>
+    <Range sha1="d5af843e9f9a1154ae610a30c71698089a298215">40 </Range>
+    <Range sha1="a98956e9a1801e612a1c07a0aa0f0c57be86c671">42-43 </Range>
+    <Range sha1="a121482d334a2bd9a42c444f99fe365ddf83a758">45 </Range>
+    <Range sha1="f619721549e15de1d6d5f7be85f9942140ae0d16">47 </Range>
+    <Range sha1="196df31f78d0e3cb623d4496e6237c4e9683cd81">49-50 </Range>
+    <Range sha1="f4cba9e7822dfb5206874e2a952681c53c513a71">52-53 </Range>
+    <Range sha1="7794743dc660f6ef29577b01af7146f6ad682a89">55-56 </Range>
+    <Range sha1="557fac47c5ae2476c04054b73680e531eeba116e">60-63 </Range>
+    <Range sha1="dba433052c7009aa4cbfdf81dabc17b285b8d087">65-67 </Range>
+    <Range sha1="55ab7ef8c797e942ea110aadcd22b55b19734ad3">70 </Range>
+    <Range sha1="2797a838edf16114b587d349da5b6c999290b02f">72 </Range>
+    <Range sha1="594cc8b274a0a92f2489765ca35545e1118d2375">78-80 </Range>
+    <Range sha1="e5f421fc2bdcdddd1f1f7081355091d5ec116930">82-83 </Range>
+    <Range sha1="c152f2a6e5eb08eae7122eabe8de71abb67fa810">85 </Range>
+    <Range sha1="67de1912c30546a2a0debca8ae41a0605a6eaa1a">88 </Range>
+    <Range sha1="b87c912352c16d33f056be47e26ece50375e560e">90-91 </Range>
+    <Range sha1="2976768755f1b5dd3a6386f8ade4887022024660">96 </Range>
+    <Range sha1="045ae769f1de3d99b35362b7e309609b6ff39886">98-105 </Range>
+    <Range sha1="dc6ba49fd6639a416c515575cd3c1a18bbbd77d7">111 </Range>
+    <Range sha1="b489f230fa3d578aeeb64d15d3ceba9c3f7fac18">114-116 </Range>
+    <Range sha1="29645cb904ec22f017fd24a8d5a188329cca1bdf">119-133 </Range>
+    <Range sha1="b25d6cd7311fd4b132e085b4649ca6af663f290b">135 </Range>
+    <Range sha1="8cba06dbce2c88a2d8370ab28c696e5871a3e80f">137 </Range>
+    <Range sha1="c5143c106c7cdb1324e55b862d8f3a7c7773fbd2">140 </Range>
+    <Range sha1="386e2a53aff173f7c8432a33ba9f115cb0f3f2dd">142-144 </Range>
+    <Range sha1="9536bce6180a813bf09b555bef8cc385c2250155">146-147 </Range>
+    <Range sha1="0b615f57ce2368bc58a03adab323d1fc40182ada">150-151 </Range>
+    <Range sha1="fa2982eb55d8302d534719e2099405e3cf10ab20">155 </Range>
+    <Range sha1="2867488d3abd8f16805c19e0ec639aebff9ff5b2">157 </Range>
+    <Range sha1="98cbb098a082e8c9c42945c38f057cc911b2e892">159-160 </Range>
+    <Range sha1="2627075946035748c9e341adc915edfdb1a97bc8">163-174 </Range>
+    <Range sha1="1a34d6fc1e86e38d5e5c4e3fb50e7f9b2e07870d">177 </Range>
+    <Range sha1="e170e81e69f8301d331382378823b5b2a577b670">181-186 </Range>
+    <Range sha1="1d463c99d29fb207fc7fd36bb297218294b851af">188-189 </Range>
+    <Range sha1="39652579027a70352fb8ee9ba94fe5bff486de6e">191 </Range>
+    <Range sha1="bee29c4d8f84c068a1be05a22aaf20c2e1f5fb92">193 </Range>
+    <Range sha1="959bba0c61e2e25d87af92e882d2d7d851376e72">195 </Range>
+    <Range sha1="dbca3770aa48e9e05629f8890d1b2330be709b8a">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/data/invalid/file-checksum/version-1.4.bmap
+++ b/test/data/invalid/file-checksum/version-1.4.bmap
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<!-- This file has extra whitespace and comments removed
+     to invalidate the BmapFileChecksum for testing -->
+<bmap version="1.4">
+  <ImageSize>821752</ImageSize>
+  <BlockSize>4096</BlockSize>
+  <BlocksCount>201</BlocksCount>
+  <MappedBlocksCount>117</MappedBlocksCount>
+  <ChecksumType>sha256 </ChecksumType>
+  <BmapFileChecksum>4310fd457a88d307abeeb593a7888e1fa3cae0cfc01d905158967c904c5375e5 </BmapFileChecksum>
+  <BlockMap>
+    <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500">0-1 </Range>
+    <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2">3-5 </Range>
+    <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66">9-10 </Range>
+    <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196">12 </Range>
+    <Range chksum="f9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a">15-18 </Range>
+    <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a">20 </Range>
+    <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6">22 </Range>
+    <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371">24 </Range>
+    <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876">30-32 </Range>
+    <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6">34-35 </Range>
+    <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae">40 </Range>
+    <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea">42-43 </Range>
+    <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195">45 </Range>
+    <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970">47 </Range>
+    <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1">49-50 </Range>
+    <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4">52-53 </Range>
+    <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28">55-56 </Range>
+    <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336">60-63 </Range>
+    <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6">65-67 </Range>
+    <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f">70 </Range>
+    <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779">72 </Range>
+    <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090">78-80 </Range>
+    <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f">82-83 </Range>
+    <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654">85 </Range>
+    <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0">88 </Range>
+    <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6">90-91 </Range>
+    <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa">96 </Range>
+    <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017">98-105 </Range>
+    <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6">111 </Range>
+    <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930">114-116 </Range>
+    <Range chksum="483e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399">119-133 </Range>
+    <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec">135 </Range>
+    <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a">137 </Range>
+    <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5">140 </Range>
+    <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0">142-144 </Range>
+    <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37">146-147 </Range>
+    <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913">150-151 </Range>
+    <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178">155 </Range>
+    <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820">157 </Range>
+    <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370">159-160 </Range>
+    <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094">163-174 </Range>
+    <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98">177 </Range>
+    <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9">181-186 </Range>
+    <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258">188-189 </Range>
+    <Range chksum="229690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384">191 </Range>
+    <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965">193 </Range>
+    <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900">195 </Range>
+    <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/data/invalid/file-checksum/version-2.0.bmap
+++ b/test/data/invalid/file-checksum/version-2.0.bmap
@@ -1,0 +1,61 @@
+<?xml version="1.0" ?>
+<!-- This file has extra whitespace and comments removed
+     to invalidate the BmapFileChecksum for testing -->
+<bmap version="2.0">
+  <ImageSize>821752</ImageSize>
+  <BlockSize>4096</BlockSize>
+  <BlocksCount>201</BlocksCount>
+  <MappedBlocksCount>117</MappedBlocksCount>
+  <ChecksumType>sha256 </ChecksumType>
+  <BmapFileChecksum>d9cf7d44790d04fcbb089c5eeec7700e9233439ab6e4bd759035906e20f90070</BmapFileChecksum>
+  <BlockMap>
+    <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500">0-1 </Range>
+    <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2">3-5 </Range>
+    <Range chksum="9251ec146af47d2db881b4beabf39e8a09f400e9fdd587080ba872be250bfa66">9-10 </Range>
+    <Range chksum="1f82b9594a9385934f7d62ad2c95b680adb0a715311da24a592353f4eedc9196">12 </Range>
+    <Range chksum="f9abfd404b01ee6cc3aae89c0b2d32595d174067414d4c7ed347e01027e5198a">15-18 </Range>
+    <Range chksum="7a6304c0e75f1db501e01ceaf03f925adb5046de4d8f21b4453ac1f34ad9a04a">20 </Range>
+    <Range chksum="7efcfe912e7a0d603823ecd387040816d718dbe356abc33d75c7a4074b5166e6">22 </Range>
+    <Range chksum="fa89f8bfa8647f253a65547f2fec7da8220beb2abf3e83387cfde4a5adc2e371">24 </Range>
+    <Range chksum="b9b49e2335300e6c9cbc41f023b95262f1e8997a328cefac4e2ee98dbffe2876">30-32 </Range>
+    <Range chksum="73d8a6f96db05475c61905707405707d881f975c6a20c4b3860e5da9cba7d0d6">34-35 </Range>
+    <Range chksum="72ecd33adba1ce49626179d66500581e96d56b26882d1882fa73b0a8973a54ae">40 </Range>
+    <Range chksum="343b15a5df354fa45c3e3a0755c2c0c65e1e8b6b8566c96ee018e3fdf22b7fea">42-43 </Range>
+    <Range chksum="67632b2bd1704a7d3535fcd1224d1cc2e5defe5f8503416aba108deb0a8c5195">45 </Range>
+    <Range chksum="567853b6db8ba8fc6b74b68bd054c4570c94c563421c791d4282271b218d1970">47 </Range>
+    <Range chksum="4c6bea2040e058ac183e4f89740b6519e0acf7690cc8c1e3a92d4cadde18afc1">49-50 </Range>
+    <Range chksum="a6923635cd40a502321dad8127db631eaae77af1adbd7c3af28e4c47a6cc17b4">52-53 </Range>
+    <Range chksum="754d4a59d22aa4e635c12da22437a2980a47cac1ffd3e9319a16e935517a3d28">55-56 </Range>
+    <Range chksum="d03670c239e2f30ef065da9848cef9f5386543d1d25bdce3b6b060f846c02336">60-63 </Range>
+    <Range chksum="7c1092388c70a7f20eb73245cb3253c8a3e94fe4727c89ccc8175a83931f30c6">65-67 </Range>
+    <Range chksum="69f6917acf67c408c6f904a0b4d1e4731fc63fcebf96b863c46e1f1345b89d5f">70 </Range>
+    <Range chksum="584951a12f0a64d605cf5c40ecc5c35fea09320215b078ff1409a6c8cb53d779">72 </Range>
+    <Range chksum="983775dfe44cf57c9c16f388fb0a0feb70b1fe1df5c15ccadf06fb52c687e090">78-80 </Range>
+    <Range chksum="7792004ce7de28e55cee7ad365760e2717ed10ba85bd732fee821eada3ed851f">82-83 </Range>
+    <Range chksum="9422e34ab590d8396203744c680411526d5ef1a9e75815a4c5f26fb45233c654">85 </Range>
+    <Range chksum="bb8fbdd5ee992341e0344284f9ef2fd60f7fcc66022d5ddf5167cb4dbf4d77e0">88 </Range>
+    <Range chksum="d7c2fe248a1f4faba0beb7ed7982721af09e43d39ba031adc47b92b7a512c2a6">90-91 </Range>
+    <Range chksum="462a930c88a2e3c5319559feb39389c64b6c21dc2cb68552e7499208bd7103aa">96 </Range>
+    <Range chksum="16dab0a1420bcf3fb47676ad3cf63d37018359bf8d74f69bda6deb584defe017">98-105 </Range>
+    <Range chksum="dde77bda930499f1ca1f5926f3bbce02628312744035031ac985953c2b992fd6">111 </Range>
+    <Range chksum="e53e4350a4a6f24d8535fe1889fd51620eb767ba9edf1f54e4716075024b4930">114-116 </Range>
+    <Range chksum="483e868aa797d861b15623755e99e195b9bd2ae21cf65e13cbc3a31196ff1399">119-133 </Range>
+    <Range chksum="c246d08bfb4c637c8ba4bc36de01c6d0a0fa1ccb6ce5073f36bee03553930dec">135 </Range>
+    <Range chksum="112bf5a172bddfdaa3547ec75cec2e06f53469092877d3235f4875a5f2d27a6a">137 </Range>
+    <Range chksum="cb0bd3e46ba71a0107e6565fcf9dd74e77890ef8e44233c2e622083264e32ee5">140 </Range>
+    <Range chksum="84cd195fb6ba711efaab2c726a4b022b59c35411288ea195ac8de7c55770b8a0">142-144 </Range>
+    <Range chksum="4581295e35fcc3192c67516f296833a0d7efb60c682ec5eb41d478fd471c7d37">146-147 </Range>
+    <Range chksum="265121e906434c8f824116152a774d6f29d64dd9d824742437a1b43337376913">150-151 </Range>
+    <Range chksum="751a8b29e92c1af64c0298c14e823b36c2e595d2b8f40e88a74a9cfec7969178">155 </Range>
+    <Range chksum="f5323d152b5fa270485f8405d14697a3c85e7ebd81191b4d63472537d4e12820">157 </Range>
+    <Range chksum="bfb2148640de1bfe102cd005978ccc06ee4d1da40b4f9ba62c0ed1ce62c08370">159-160 </Range>
+    <Range chksum="dafa3fbd9fb00807231520ed080d412b16e7a64f2f22e5252ba435bba13f3094">163-174 </Range>
+    <Range chksum="75678fa3017705a5c4015668beb2f69a88c7ad1ca981468ad9bac0322db90c98">177 </Range>
+    <Range chksum="1e11b14396428302f3e6a6b770a5d55bd4211fd952a9acf5acad8996257615a9">181-186 </Range>
+    <Range chksum="c9bb5fa33c4dee6cb6f846017dfca8ab33e5b211cb1dfa1a92fc26ce21ebf258">188-189 </Range>
+    <Range chksum="229690ebe7f88e243b5b1ba3a87b20fa21cb63c52c31315c65c9075074be9384">191 </Range>
+    <Range chksum="38997ca7da7129a382db6138e8f42102a22a482f859ddb9bdc2fba8a44fe1965">193 </Range>
+    <Range chksum="af30597da547c8c0cf124b33159644f089ba2e172bddc1fe2864d80183565900">195 </Range>
+    <Range chksum="cb732fc3f3a0f81f6a761a534201c05549c8efe4a92630ccd24241f72d7d618c">198-199 </Range>
+  </BlockMap>
+</bmap>

--- a/test/data/stringified.bmap
+++ b/test/data/stringified.bmap
@@ -5,7 +5,7 @@
   <BlocksCount>201</BlocksCount>
   <MappedBlocksCount>117</MappedBlocksCount>
   <ChecksumType>sha256</ChecksumType>
-  <BmapFileChecksum>fbfc7dac6f7308ba98c83dc165f56b0eb8b2a13a8d3be0569f6369e4d6f6eb2c</BmapFileChecksum>
+  <BmapFileChecksum>b712e55b4991cecc00e1f5ed9aff3c115963c7c2e174361c3cd3279f5e6d31ad</BmapFileChecksum>
   <BlockMap>
     <Range chksum="9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500">0-1</Range>
     <Range chksum="e8a26f49a71262870f8294a73f40f122d622fd70fb82bef01c0322785e9fd6b2">3-5</Range>

--- a/test/data/version-1.2.json
+++ b/test/data/version-1.2.json
@@ -4,6 +4,7 @@
   "blockSize": 4096,
   "blockCount": 201,
   "mappedBlockCount": 117,
+  "checksum": null,
   "checksumType": "sha1",
   "ranges": [{
     "checksum": "94789636db14cdb8929133e7b8d3a158837e2e5a",

--- a/test/data/version-1.3.json
+++ b/test/data/version-1.3.json
@@ -4,6 +4,7 @@
   "blockSize": 4096,
   "blockCount": 201,
   "mappedBlockCount": 117,
+  "checksum": "e235f7cd0c6b8c07a2e6f2538510fb763e7790a6",
   "checksumType": "sha1",
   "ranges": [{
     "checksum": "94789636db14cdb8929133e7b8d3a158837e2e5a",

--- a/test/data/version-1.4.json
+++ b/test/data/version-1.4.json
@@ -4,6 +4,7 @@
   "blockSize": 4096,
   "blockCount": 201,
   "mappedBlockCount": 117,
+  "checksum": "4310fd457a88d307abeeb593a7888e1fa3cae0cfc01d905158967c904c5375e5",
   "checksumType": "sha256",
   "ranges": [{
     "checksum": "9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500",

--- a/test/data/version-2.0.json
+++ b/test/data/version-2.0.json
@@ -4,6 +4,7 @@
   "blockSize": 4096,
   "blockCount": 201,
   "mappedBlockCount": 117,
+  "checksum": "d9cf7d44790d04fcbb089c5eeec7700e9233439ab6e4bd759035906e20f90070",
   "checksumType": "sha256",
   "ranges": [{
     "checksum": "9eaf19215d55d23de1be1fe4bed4a95bfe620a404352fd06e782738fff58e500",

--- a/test/parse.js
+++ b/test/parse.js
@@ -31,4 +31,28 @@ describe( 'BlockMap.parse()', function() {
     })
   })
 
+  context( 'when file checksum is invalid', function() {
+
+    // NOTE: Version 1.2 has no support for file checksums
+    ;[ '1.3', '1.4', '2.0' ].forEach( function( v ) {
+      it( `throws on invalid checksum for v${v}`, function() {
+        var json = require( `./data/version-${v}` )
+        var xml = fs.readFileSync( path.join( __dirname, `/data/invalid/file-checksum/version-${v}.bmap` ) )
+        assert.throws( function() {
+          BlockMap.parse( xml )
+        }, /^Error: File checksum mismatch:/, `Version ${v}` )
+      })
+    })
+
+    // NOTE: Version 1.2 has no support for file checksums
+    ;[ '1.3', '1.4', '2.0' ].forEach( function( v ) {
+      it( `does not throw with verification disabled for v${v}`, function() {
+        var json = require( `./data/version-${v}` )
+        var xml = fs.readFileSync( path.join( __dirname, `/data/invalid/file-checksum/version-${v}.bmap` ) )
+        assert.deepEqual( json, BlockMap.parse( xml, { verify: false }), `Version ${v}` )
+      })
+    })
+
+  })
+
 })

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -14,11 +14,10 @@ describe( 'BlockMap.stringify()', function() {
     assert.strictEqual( blockMap.toString(), compare )
   })
 
-  it( 'parses own ouput', function() {
-    var json = require( `./data/version-2.0` )
+  it( 'has equivalent input & output', function() {
     var xml = fs.readFileSync( path.join( __dirname, `/data/stringified.bmap` ) )
     var blockMap = BlockMap.parse( xml )
-    assert.deepEqual( json, BlockMap.parse( xml ) )
+    assert.deepEqual( xml.toString(), blockMap.toString() )
   })
 
 })


### PR DESCRIPTION
Connects to #7, #6 

This implements verification of a block map's file checksum when parsing a `.bmap` file, and adds an option to `BlockMap.parse()` to disable it by passing `{ verify: false }` as options.

Example:
```js
// This will throw, if the file's checksum doesn't check out
var bmap = BlockMap.parse( xml )
// This will happily ignore verifying it
var bmap = BlockMap.parse( xml, { verify: false })
```