### PR TITLE
fix(filter-stream): Prevent emitting too small blocks

### DIFF
--- a/lib/filter-stream.js
+++ b/lib/filter-stream.js
@@ -24,6 +24,7 @@ function FilterStream( blockMap, options ) {
   /** @type {Object} options */
   this.options = options || {}
 
+  this.options.readableObjectMode = true
   this.options.verify = this.options.verify != null ?
     !!this.options.verify : true
 
@@ -176,7 +177,7 @@ function FilterStream( blockMap, options ) {
     var buffer = Buffer.concat( this._buffers )
     var offset = 0
 
-    while( offset < buffer.length ) {
+    while( buffer.length - offset >= this.blockSize ) {
       this._pushBlock( buffer.slice( offset, offset + this.blockSize ) )
       offset = offset + this.blockSize
     }
@@ -187,6 +188,18 @@ function FilterStream( blockMap, options ) {
     this._bytes = buffer.length
 
     next()
+
+  },
+
+  _flush( done ) {
+
+    var buffer = Buffer.concat( this._buffers )
+    var block = Buffer.alloc( this.blockSize )
+
+    buffer.copy( block )
+    this._pushBlock( block )
+
+    done()
 
   },
 

--- a/test/filter-stream.js
+++ b/test/filter-stream.js
@@ -16,6 +16,34 @@ describe( 'BlockMap.FilterStream', function() {
     readStream.pipe( transform )
       .on( 'data', ( block ) => {
         blockCount++
+        assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+        assert.ok( block.address != null, 'block address missing' )
+        assert.ok( block.position != null, 'block position missing' )
+      })
+      .once( 'error', done )
+      .once( 'end', function() {
+        assert.equal( this.blocksWritten, blockMap.mappedBlockCount, 'blocksRead mismatch' )
+        assert.equal( this.bytesWritten, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesWritten mismatch' )
+        assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
+        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        done()
+      })
+
+  })
+
+
+  it( 'should only emit properly sized blocks', function( done ) {
+
+    var filename = path.join( __dirname, '/data/bmap.img' )
+    var blockMap = BlockMap.create( require( './data/version-2.0' ) )
+    var readStream = fs.createReadStream( filename, { highWaterMark: 123 })
+    var transform = new BlockMap.FilterStream( blockMap )
+    var blockCount = 0
+
+    readStream.pipe( transform )
+      .on( 'data', ( block ) => {
+        blockCount++
+        assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -40,7 +68,12 @@ describe( 'BlockMap.FilterStream', function() {
         var readStream = fs.createReadStream( filename )
         var transform = new BlockMap.FilterStream( blockMap, { verify: false })
 
-        readStream.pipe( transform ).resume()
+        readStream.pipe( transform )
+          .on( 'data', ( block ) => {
+            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.ok( block.address != null, 'block address missing' )
+            assert.ok( block.position != null, 'block position missing' )
+          })
           .on( 'error', done )
           .on( 'end', done )
 
@@ -58,7 +91,12 @@ describe( 'BlockMap.FilterStream', function() {
         var readStream = fs.createReadStream( filename )
         var transform = new BlockMap.FilterStream( blockMap )
 
-        readStream.pipe( transform ).resume()
+        readStream.pipe( transform )
+          .on( 'data', ( block ) => {
+            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.ok( block.address != null, 'block address missing' )
+            assert.ok( block.position != null, 'block position missing' )
+          })
           .on( 'error', function( error ) {
             assert.ok( error instanceof Error, 'error not instance of Error' )
             // The calculated checksum
@@ -88,7 +126,12 @@ describe( 'BlockMap.FilterStream', function() {
         var transform = new BlockMap.FilterStream( blockMap, { verify: true })
         var hadErrors = 0
 
-        readStream.pipe( transform ).resume()
+        readStream.pipe( transform )
+          .on( 'data', ( block ) => {
+            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.ok( block.address != null, 'block address missing' )
+            assert.ok( block.position != null, 'block position missing' )
+          })
           .on( 'error', function( error ) {
             assert.ok( error instanceof Error, 'error not instance of Error' )
             assert.ok( /^Invalid checksum for range/.test( error.message ) )


### PR DESCRIPTION
Due to an error in how blocks were chunked, it was possible to emit too small or improperly sized blocks when encountering backpressure buffering.

This fixes that behavior, and ensures that all read buffers are consumed.