### PR TITLE
feat(read-stream): Refactor & optimize BlockMap.ReadStream

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -31,20 +31,23 @@
             * [.position](#BlockMap.FilterStream+position) : <code>Number</code>
         * [.ReadStream](#BlockMap.ReadStream)
             * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
-            * [.options](#BlockMap.ReadStream+options) : <code>Object</code>
             * [.fd](#BlockMap.ReadStream+fd) : <code>Number</code>
             * [.path](#BlockMap.ReadStream+path) : <code>String</code>
             * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
             * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
             * [.blockSize](#BlockMap.ReadStream+blockSize) : <code>Number</code>
+            * [.verify](#BlockMap.ReadStream+verify) : <code>Boolean</code>
             * [.currentRange](#BlockMap.ReadStream+currentRange) : <code>BlockMap.Range</code>
-            * [.blockInRange](#BlockMap.ReadStream+blockInRange) : <code>Number</code>
             * [.rangesRead](#BlockMap.ReadStream+rangesRead) : <code>Number</code>
             * [.blocksRead](#BlockMap.ReadStream+blocksRead) : <code>Number</code>
             * [.bytesRead](#BlockMap.ReadStream+bytesRead) : <code>Number</code>
             * [.position](#BlockMap.ReadStream+position) : <code>Number</code>
             * [.start](#BlockMap.ReadStream+start) : <code>Number</code>
             * [.end](#BlockMap.ReadStream+end) : <code>Number</code>
+            * [.closed](#BlockMap.ReadStream+closed) : <code>Boolean</code>
+            * [.destroyed](#BlockMap.ReadStream+destroyed) : <code>Boolean</code>
+            * [.close([callback])](#BlockMap.ReadStream+close)
+            * [.destroy()](#BlockMap.ReadStream+destroy)
         * [.versions](#BlockMap.versions) : <code>Array</code>
         * [.create([options])](#BlockMap.create) ⇒ <code>[BlockMap](#BlockMap)</code>
         * [.fromJSON(data)](#BlockMap.fromJSON) ⇒ <code>[BlockMap](#BlockMap)</code>
@@ -305,20 +308,23 @@ Current offset in bytes
 
 * [.ReadStream](#BlockMap.ReadStream)
     * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
-    * [.options](#BlockMap.ReadStream+options) : <code>Object</code>
     * [.fd](#BlockMap.ReadStream+fd) : <code>Number</code>
     * [.path](#BlockMap.ReadStream+path) : <code>String</code>
     * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
     * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
     * [.blockSize](#BlockMap.ReadStream+blockSize) : <code>Number</code>
+    * [.verify](#BlockMap.ReadStream+verify) : <code>Boolean</code>
     * [.currentRange](#BlockMap.ReadStream+currentRange) : <code>BlockMap.Range</code>
-    * [.blockInRange](#BlockMap.ReadStream+blockInRange) : <code>Number</code>
     * [.rangesRead](#BlockMap.ReadStream+rangesRead) : <code>Number</code>
     * [.blocksRead](#BlockMap.ReadStream+blocksRead) : <code>Number</code>
     * [.bytesRead](#BlockMap.ReadStream+bytesRead) : <code>Number</code>
     * [.position](#BlockMap.ReadStream+position) : <code>Number</code>
     * [.start](#BlockMap.ReadStream+start) : <code>Number</code>
     * [.end](#BlockMap.ReadStream+end) : <code>Number</code>
+    * [.closed](#BlockMap.ReadStream+closed) : <code>Boolean</code>
+    * [.destroyed](#BlockMap.ReadStream+destroyed) : <code>Boolean</code>
+    * [.close([callback])](#BlockMap.ReadStream+close)
+    * [.destroy()](#BlockMap.ReadStream+destroy)
 
 
 -
@@ -340,15 +346,6 @@ ReadStream
     - [.start] <code>Number</code> - byte offset in file to read from
     - [.end] <code>Number</code> - byte offset in file to stop at
 
-
--
-
-<a name="BlockMap.ReadStream+options"></a>
-
-#### readStream.options : <code>Object</code>
-options
-
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
 
 -
 
@@ -397,19 +394,19 @@ Size of a mapped block in bytes
 
 -
 
-<a name="BlockMap.ReadStream+currentRange"></a>
+<a name="BlockMap.ReadStream+verify"></a>
 
-#### readStream.currentRange : <code>BlockMap.Range</code>
-Range being currently processed
+#### readStream.verify : <code>Boolean</code>
+Whether or not to verify range checksums
 
 **Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
 
 -
 
-<a name="BlockMap.ReadStream+blockInRange"></a>
+<a name="BlockMap.ReadStream+currentRange"></a>
 
-#### readStream.blockInRange : <code>Number</code>
-Current block in range
+#### readStream.currentRange : <code>BlockMap.Range</code>
+Range being currently processed
 
 **Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
 
@@ -466,6 +463,46 @@ Position start offset in bytes
 End offset in bytes
 
 **Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+
+-
+
+<a name="BlockMap.ReadStream+closed"></a>
+
+#### readStream.closed : <code>Boolean</code>
+Whether the stream has been closed
+
+**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+
+-
+
+<a name="BlockMap.ReadStream+destroyed"></a>
+
+#### readStream.destroyed : <code>Boolean</code>
+Whether the stream has been destroyed
+
+**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+
+-
+
+<a name="BlockMap.ReadStream+close"></a>
+
+#### readStream.close([callback])
+Close the stream, and the underlying file handle
+
+**Kind**: instance method of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Params**
+
+- [callback] <code>function</code> - callback(error)
+
+
+-
+
+<a name="BlockMap.ReadStream+destroy"></a>
+
+#### readStream.destroy()
+Destroy the stream, release any internal resources
+
+**Kind**: instance method of <code>[ReadStream](#BlockMap.ReadStream)</code>  
 
 -
 

--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -2,6 +2,7 @@ var stream = require( 'stream' )
 var fs = require( 'fs' )
 var inherit = require( 'bloodline' )
 var crypto = require( 'crypto' )
+var debug = require( 'debug' )( 'blockmap:readstream' )
 
 /**
  * ReadStream
@@ -27,32 +28,29 @@ function ReadStream( filename, blockMap, options ) {
     throw new Error( 'Missing block map' )
   }
 
-  /** @type {Object} options */
-  this.options = options || {}
+  options = options || {}
 
   if( filename == null && options.fd == null ) {
     throw new Error( 'Missing filename or file descriptor' )
   }
 
-  this.options.verify = this.options.verify != null ?
-    !!this.options.verify : true
-
-  stream.Readable.call( this, this.options )
+  stream.Readable.call( this, options )
 
   /** @type {Number} File descriptor */
-  this.fd = this.options.fd || null
+  this.fd = options.fd || null
   /** @type {String} File path */
   this.path = filename
   /** @type {String} File open flags */
-  this.flags = this.options.flags || 'r'
+  this.flags = options.flags || 'r'
   /** @type {BlockMap} The block map */
   this.blockMap = blockMap
   /** @type {Number} Size of a mapped block in bytes */
   this.blockSize = this.blockMap.blockSize
+  /** @type {Boolean} Whether or not to verify range checksums */
+  this.verify = options.verify != null ?
+    !!options.verify : true
   /** @type {BlockMap.Range} Range being currently processed */
   this.currentRange = null
-  /** @type {Number} Current block in range */
-  this.blockInRange = 0
   /** @type {Number} Number of block map ranges read */
   this.rangesRead = 0
   /** @type {Number} Number of blocks read */
@@ -62,10 +60,14 @@ function ReadStream( filename, blockMap, options ) {
   /** @type {Number} Current offset in bytes */
   this.position = 0
   /** @type {Number} Position start offset in bytes */
-  this.start = this.options.start || 0
+  this.start = options.start || 0
   /** @type {Number} End offset in bytes */
-  this.end = this.options.end != null ?
-    this.options.end : Infinity
+  this.end = options.end != null ?
+    options.end : Infinity
+  /** @type {Boolean} Whether the stream has been closed */
+  this.closed = false
+  /** @type {Boolean} Whether the stream has been destroyed */
+  this.destroyed = false
 
   if( this.start < 0 ) {
     throw new Error( 'Start must not be negative' )
@@ -80,15 +82,17 @@ function ReadStream( filename, blockMap, options ) {
    * @type {crypto.Hash}
    * @private
    */
-  this._hash = this.options.verify ?
+  this._hash = this.verify ?
     crypto.createHash( this.blockMap.checksumType ) : null
 
   /**
-   * Whether there's a read in progress
-   * @type {Boolean}
+   * Ranges to be read from the image
+   * @type {Array<Object>}
    * @private
    */
-  this._isReading = false
+  this.ranges = this._prepareRanges()
+
+  this.open()
 
 }
 
@@ -101,53 +105,42 @@ ReadStream.prototype = {
 
   constructor: ReadStream,
 
-  get rangeBlockCount() {
-    return this.currentRange &&
-      this.currentRange.end - this.currentRange.start + 1
-  },
+  get highWaterMark() { return this._readableState.highWaterMark },
+  set highWaterMark( value ) { this._readableState.highWaterMark },
 
-  _onError( error ) {
-    this.destroy()
-    this.emit( 'error', error )
-  },
-
-  _close() {
-
-    if( !this.options.autoClose ) {
-      return this.push( null )
-    }
-
-    fs.close( this.fd, ( error ) => {
-      this.fd = null
-      this.push( null )
+  /**
+   * Preprocess the `blockMap`'s ranges into byte-ranges
+   * with respect to the `start` offset, and an `offset`
+   * for tracking chunked range reading
+   * @returns {Array<Object>} byteRanges
+   * @private
+   */
+  _prepareRanges() {
+    return this.blockMap.ranges.map(( range ) => {
+      return {
+        checksum: range.checksum,
+        start: (range.start * this.blockSize) + this.start,
+        end: ((range.end + 1) * this.blockSize) + this.start,
+        length: (range.end - range.start + 1) * this.blockSize,
+        startLBA: range.start,
+        endLBA: range.end,
+        offset: 0,
+      }
+    }).filter(( range ) => {
+      return range.end <= (this.end + this.start)
     })
-
-  },
-
-  _open( callback ) {
-
-    if( this.fd != null ) {
-      return callback.call( this )
-    }
-
-    fs.open( this.path, this.flags, ( error, fd ) => {
-      if( error ) return this._onError( error )
-      this.fd = fd
-      callback.call( this )
-    })
-
   },
 
   /**
-   * Verify the current range, if completed,
-   * and emit an error on mismatch
+   * Verify a fully read range's checksum against
+   * the range's checksum from the blockmap
    * @private
    */
   _verifyRange() {
 
-    var needsVerify = this.options.verify &&
+    var needsVerify = this.verify &&
       this.currentRange != null &&
-      this.blockInRange >= this.rangeBlockCount
+      this.currentRange.offset === this.currentRange.length
 
     if( !needsVerify ) return
 
@@ -155,10 +148,13 @@ ReadStream.prototype = {
     var digest = this._hash.digest( 'hex' )
     var error = null
 
+    debug( 'verify:checksum', range.checksum )
+    debug( 'verify:digest  ', digest )
+
     this._hash = crypto.createHash( this.blockMap.checksumType )
 
     if( range.checksum !== digest ) {
-      error = new Error( 'Invalid checksum for range [' + range.start + ',' + range.end + ']' )
+      error = new Error( `Invalid checksum for range [${range.startLBA},${range.endLBA}], bytes ${range.start}-${range.end}` )
       error.checksum = digest
       error.range = range
       this.emit( 'error', error )
@@ -167,98 +163,156 @@ ReadStream.prototype = {
   },
 
   /**
-   * Read one block from the source
+   * Read the current range (or a chunk thereof),
+   * update state and emit the read block
    * @private
    */
   _readBlock() {
 
     var range = this.currentRange
-    var block = this.blockInRange++
-    var position = ( range.start + block ) * this.blockSize
-    var length = this.blockSize
-    var buffer = Buffer.allocUnsafe( this.blockSize )
+    var length = Math.min( range.length - range.offset, this.highWaterMark )
+    var position = range.start + range.offset
+    var buffer = Buffer.allocUnsafe( length )
+    var offset = 0
 
-    this._isReading = true
+    debug( 'read-block:position', position )
+    debug( 'read-block:length', length )
 
-    // NOTE: Adding properties to core objects
-    // is not good practice, but should suffice as a PoC
-    buffer.address = range.start
-    // NOTE: `buffer.offset` doesn't fly,
-    // as it's an undocumented getter on Buffers
-    buffer.position = position
+    fs.read( this.fd, buffer, offset, length, position, ( error, bytesRead ) => {
 
-    this.position = this.start + position
-
-    if( this.position >= this.end ) {
-      this._isReading = false
-      return this._close()
-    }
-
-    fs.read( this.fd, buffer, 0, length, this.position, ( error, bytesRead, buffer ) => {
-
-      if( bytesRead !== length ) {
-        return this.emit( 'error', new Error( 'Bytes read mismatch: ' + bytesRead + ' != ' + length ) )
+      if( error == null && bytesRead !== length ) {
+        error = new Error( 'Bytes read mismatch: ' + bytesRead + ' != ' + length )
       }
 
-      this.blocksRead++
+      if( error ) {
+        if( this.autoClose ) {
+          this.destroy()
+        }
+        this.emit( 'error', error )
+        return
+      }
+
+      buffer.position = position
+      buffer.address = position / this.blockSize
+
+      range.offset += bytesRead
+
+      this.blocksRead += bytesRead / this.blockSize
       this.bytesRead += bytesRead
       this.position += bytesRead
 
+      debug( 'read-block:blocksRead', this.blocksRead )
+
       // Feed the hash if we're verifying
-      if( this.options.verify ) {
+      if( this.verify ) {
         this._hash.update( buffer )
       }
 
-      // Check if we should continue reading
-      if( this.push( buffer ) ) {
-        this._isReading = false
-        // If we've hit the end of the range,
-        // proceed to the next range
-        if( this.blockInRange >= this.rangeBlockCount ) {
-          this._read()
-        } else {
-          this._readBlock()
-        }
-      }
+      this.push( buffer )
 
     })
 
   },
 
+  /**
+   * Initiate a new read, advancing the range if necessary,
+   * and verifying checksums, if enabled
+   * @see https://nodejs.org/api/stream.html#stream_implementing_a_readable_stream
+   * @private
+   */
   _read() {
 
-    if( this._isReading ) return;
-
     if( this.fd == null ) {
-      return this._open( this._read )
+      return void this.once( 'open', () => { this._read() })
     }
 
-    if( this.rangesRead === this.blockMap.ranges.length ) {
-      return this._close()
+    if( this.ranges.length === 0 ) {
+      return void this.push( null )
     }
 
-    // If we're either reading the first block, or have completed a block range;
-    // verify, then switch to next range & continue block reads
-    if( this.currentRange == null || this.blockInRange >= this.rangeBlockCount ) {
+    if( this.currentRange == null || this.currentRange.offset === this.currentRange.length ) {
       this._verifyRange()
-      this.currentRange = this.blockMap.ranges[ this.rangesRead++ ]
-      this.blockInRange = 0
-      this._readBlock()
+      this.currentRange = this.ranges.shift()
+      this.rangesRead++
+      debug( 'read:range %O', this.currentRange )
     }
+
+    this._readBlock()
 
   },
 
-  destroy() {
+  /**
+   * Open a handle to the image file in question
+   * @private
+   */
+  open() {
 
-    if( !this.options.autoClose ) {
-      stream.Readable.prototype.destroy.call( this )
+    if( this.fd != null ) {
       return
     }
 
-    fs.close( this.fd, ( error ) => {
-      this.fd = null
-      stream.Readable.prototype.destroy.call( this )
+    fs.open( this.path, this.flags, ( error, fd ) => {
+      if( error ) {
+        if( this.autoClose ) {
+          this.destroy()
+        }
+        this.emit( 'error', error )
+      } else {
+        this.fd = fd
+        this.emit( 'open', this.fd )
+      }
     })
+
+  },
+
+  /**
+   * Close the stream, and the underlying file handle
+   * @param {Function} [callback] - callback(error)
+   */
+  close( callback ) {
+
+    if( callback ) {
+      this.once( 'close', callback )
+    }
+
+    if( this.closed || this.fd == null ) {
+      if( this.fd == null ) {
+        this.once( 'open', () => {
+          this.close()
+        })
+      } else {
+        process.nextTick(() => {
+          this.emit( 'close' )
+        })
+      }
+      return
+    }
+
+    this.closed = true
+
+    fs.close( this.fd, ( error ) => {
+      if( error != null ) {
+        this.emit( 'error', error )
+      } else {
+        this.emit( 'close' )
+      }
+    })
+
+    this.fd = null
+
+  },
+
+  /**
+   * Destroy the stream, release any internal resources
+   */
+  destroy() {
+
+    if( this.destroyed ) {
+      return
+    }
+
+    this.destroyed = true
+    this.close()
 
   },
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "lib/blockmap.js",
   "dependencies": {
     "bloodline": "^1.0.0",
+    "debug": "^2.6.8",
     "htmlparser2": "^3.9.2",
     "xml": "^1.0.1"
   },

--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -10,11 +10,11 @@ describe( 'BlockMap.ReadStream', function() {
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
     var readStream = new BlockMap.ReadStream( filename, blockMap )
-    var blockCount = 0
+    var byteCount = 0
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -23,7 +23,7 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         done()
       })
 
@@ -35,11 +35,11 @@ describe( 'BlockMap.ReadStream', function() {
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
     var fd = fs.openSync( filename, 'r' )
     var readStream = new BlockMap.ReadStream( null, blockMap, { fd: fd })
-    var blockCount = 0
+    var byteCount = 0
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -48,7 +48,7 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         done()
       })
 
@@ -59,7 +59,7 @@ describe( 'BlockMap.ReadStream', function() {
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
     var fd = fs.openSync( filename, 'r' )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( null, blockMap, {
       fd: fd,
       autoClose: false,
@@ -67,7 +67,7 @@ describe( 'BlockMap.ReadStream', function() {
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -76,7 +76,7 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         assert.ok( fs.fstatSync( readStream.fd ) )
         fs.closeSync( readStream.fd )
         done()
@@ -88,14 +88,14 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       autoClose: false,
     })
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -104,7 +104,7 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         assert.ok( fs.fstatSync( readStream.fd ) )
         fs.closeSync( readStream.fd )
         done()
@@ -116,14 +116,14 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/padded-bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       start: 4096,
     })
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
@@ -132,7 +132,7 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         done()
       })
 
@@ -142,23 +142,24 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
-      end: blockMap.blockSize,
+      // This encompasses the first mapped range
+      end: blockMap.blockSize * 2,
     })
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
       .once( 'error', done )
       .once( 'end', function() {
-        assert.equal( this.blocksRead, 1, 'blocksRead mismatch' )
-        assert.equal( this.bytesRead, blockMap.blockSize, 'bytesRead mismatch' )
+        assert.equal( this.blocksRead, 2, 'blocksRead mismatch' )
+        assert.equal( this.bytesRead, blockMap.blockSize * 2, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, 1, 'rangesRead mismatch' )
-        assert.equal( blockCount, 1, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, 2, 'actual blocks read mismatch' )
         done()
       })
 
@@ -168,7 +169,7 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/padded-bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       start: 4096,
       end: 4096 + blockMap.blockSize,
@@ -176,16 +177,16 @@ describe( 'BlockMap.ReadStream', function() {
 
     readStream
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
       .once( 'error', done )
       .once( 'end', function() {
-        assert.equal( this.blocksRead, 1, 'blocksRead mismatch' )
-        assert.equal( this.bytesRead, blockMap.blockSize, 'bytesRead mismatch' )
+        assert.equal( this.blocksRead, 2, 'blocksRead mismatch' )
+        assert.equal( this.bytesRead, blockMap.blockSize * 2, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, 1, 'rangesRead mismatch' )
-        assert.equal( blockCount, 1, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, 2, 'actual blocks read mismatch' )
         done()
       })
 
@@ -200,7 +201,7 @@ describe( 'BlockMap.ReadStream', function() {
       new BlockMap.ReadStream( filename, blockMap, {
         start: -1,
       })
-    })
+    }, 'Start must not be negative' )
 
   })
 
@@ -213,7 +214,7 @@ describe( 'BlockMap.ReadStream', function() {
       new BlockMap.ReadStream( filename, blockMap, {
         end: -1,
       })
-    })
+    }, 'Start must be less or equal to end' )
 
   })
 
@@ -221,7 +222,7 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       end: 0,
     })
@@ -229,11 +230,11 @@ describe( 'BlockMap.ReadStream', function() {
     readStream
       .on( 'error', done )
       .on( 'end', () => {
-        assert.strictEqual( blockCount, 0 )
+        assert.strictEqual( byteCount, 0 )
         done()
       })
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
       })
 
   })
@@ -256,7 +257,7 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       start: blockMap.blockSize,
       end: blockMap.blockSize,
@@ -265,11 +266,11 @@ describe( 'BlockMap.ReadStream', function() {
     readStream
       .on( 'error', done )
       .on( 'end', () => {
-        assert.strictEqual( blockCount, 0 )
+        assert.strictEqual( byteCount, 0 )
         done()
       })
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
       })
 
   })
@@ -299,7 +300,7 @@ describe( 'BlockMap.ReadStream', function() {
 
     var filename = path.join( __dirname, '/data/bmap.img' )
     var blockMap = BlockMap.create( require( './data/version-2.0' ) )
-    var blockCount = 0
+    var byteCount = 0
     var readStream = new BlockMap.ReadStream( filename, blockMap, {
       end: fs.statSync( filename ).size + blockMap.blockSize,
     })
@@ -310,11 +311,11 @@ describe( 'BlockMap.ReadStream', function() {
         assert.equal( this.blocksRead, blockMap.mappedBlockCount, 'blocksRead mismatch' )
         assert.equal( this.bytesRead, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesRead mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
-        assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
+        assert.equal( byteCount / blockMap.blockSize, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
         done()
       })
       .on( 'data', ( block ) => {
-        blockCount++
+        byteCount += block.length
       })
 
   })
@@ -352,8 +353,8 @@ describe( 'BlockMap.ReadStream', function() {
             // The calculated checksum
             assert.ok( error.checksum, 'missing checksum' )
             // The faulty range's data
-            assert.strictEqual( error.range.start, 119, 'incorrect range start' )
-            assert.strictEqual( error.range.end, 133, 'incorrect range end' )
+            assert.strictEqual( error.range.startLBA, 119, 'incorrect range start' )
+            assert.strictEqual( error.range.endLBA, 133, 'incorrect range end' )
             assert.ok( error.range.checksum, 'missing "faulty" checksum' )
             hadError = true
           })


### PR DESCRIPTION
This is a major refactoring & optimization of the blockmapped `ReadStream`
to iron out some performance issues and bugs in behavior.

**Changes:**

- Add `debug` module
- **BREAKING:** Remove `.blockInRange` property
- Add `.closed` & `.destroyed` properties
- Convert blockMap's ranges to byte ranges for simplified block reading
- Add `.highWaterMark` getter/setter
- Support `autoClose` option
- Rewrite `._readBlock()` to read up to `highWaterMark` chunks within a range
  to increase throughput, and decrease CPU load and read calls
- **BREAKING:** Rewrite `open()`, `close()` and `destroy()`
  to implement the same behavior as `fs.ReadStream`
- **BREAKING:** `start` & `end` options will now cause only partially covered
  regions to **NOT** be read
- **BREAKING:** Remove `.options`, add `.verify` instead
- Update tests to match above changes

Change-Type: major