### PR TITLE
refactor(filter-stream): Refactor & optimize FilterStream

### DIFF
--- a/benchmark/read-stream.js
+++ b/benchmark/read-stream.js
@@ -41,3 +41,25 @@ bench( 'BlockMap.ReadStream', function( run ) {
   })
 
 })
+
+bench( 'BlockMap.FilterStream', function( run ) {
+
+  const filename = path.join( __dirname, '..', 'test/data/bmap.img' )
+  const blockMap = BlockMap.create( require( '../test/data/version-2.0' ) )
+  const readStream = fs.createReadStream( filename )
+  const filter = BlockMap.createFilterStream( blockMap )
+
+  run.start()
+
+  readStream.pipe( filter )
+    .on( 'readable', function() {
+      var chunk = null
+      while( chunk = this.read() ) {
+        continue
+      }
+    })
+    .once( 'end', function() {
+      run.end()
+    })
+
+})

--- a/lib/filter-stream.js
+++ b/lib/filter-stream.js
@@ -1,6 +1,7 @@
 var stream = require( 'stream' )
 var inherit = require( 'bloodline' )
 var crypto = require( 'crypto' )
+var debug = require( 'debug' )( 'blockmap:filterstream' )
 
 /**
  * FilterStream
@@ -34,8 +35,6 @@ function FilterStream( blockMap, options ) {
   this.blockMap = blockMap
   /** @type {Number} Size of a mapped block in bytes */
   this.blockSize = this.blockMap.blockSize
-  /** @type {BlockMap.Range} Range being currently processed */
-  this.currentRange = this.blockMap.ranges[0]
   /** @type {Number} Number of block map ranges read */
   this.rangesRead = 0
   /** @type {Number} Number of blocks read */
@@ -48,21 +47,20 @@ function FilterStream( blockMap, options ) {
   this.bytesWritten = 0
   /** @type {Number} Current offset in bytes */
   this.position = 0
+  /** @type {Array<Object>} Ranges */
+  this.ranges = this._getByteRangesFromBlockMap()
+  /** @type {Object} Range being currently processed */
+  this.currentRange = this.ranges.shift()
 
-  /**
-   * Internal buffer queue for chunking to block size,
-   * if source does not emit appropriately sized chunks
-   * @type {Buffer[]}
-   * @private
-   */
-  this._buffers = []
+  // Set the highWaterMark to match `fs` stream
+  // highWaterMarks of 64KB to avoid speed penalties
+  this.highWaterMark = 64 * 1024
 
-  /**
-   * Internal buffer's byte counter
-   * @type {Number}
-   * @private
-   */
+  this._chunks = []
   this._bytes = 0
+
+  debug( 'highWaterMark', this.highWaterMark )
+  debug( 'range:next', this.currentRange )
 
   /**
    * Hash stream to calculate range checksums
@@ -83,38 +81,60 @@ function FilterStream( blockMap, options ) {
 
   constructor: FilterStream,
 
+  get highWaterMark() { return this._writableState.highWaterMark },
+  set highWaterMark( value ) { this._writableState.highWaterMark = value },
+
   /**
-   * Check whether the current position is in a mapped range
+   * Preprocess the `blockMap`'s ranges into byte-ranges
+   * with respect to the `start` offset, and an `offset`
+   * for tracking chunked range reading
    * @private
-   * @param {Number} blockAddress
-   * @returns {Boolean}
+   * @returns {Array<Object>} byteRanges
    */
-  _inRange( blockAddress ) {
-    return this.currentRange &&
-      blockAddress >= this.currentRange.start &&
-      blockAddress <= this.currentRange.end
+  _getByteRangesFromBlockMap() {
+    return this.blockMap.ranges.map(( range ) => {
+      return {
+        checksum: range.checksum,
+        start: range.start * this.blockSize,
+        end: (range.end + 1) * this.blockSize,
+        length: (range.end - range.start + 1) * this.blockSize,
+        startLBA: range.start,
+        endLBA: range.end,
+        offset: 0,
+      }
+    })
   },
 
   /**
-   * Verify the current range, if completed,
-   * and emit an error on mismatch
+   * Verify a fully read range's checksum against
+   * the range's checksum from the blockmap
    * @private
    */
   _verifyRange() {
 
-    var needsVerify = this.options.verify &&
-      this.currentRange != null
+    if( !this.options.verify ) return
 
-    if( !needsVerify ) return
+    var error = null
+    var needsVerify = this.currentRange != null &&
+      this.currentRange.offset === this.currentRange.length
+
+    if( !needsVerify ) {
+      error = new Error( `Unexpected verification for range [${range.startLBA},${range.endLBA}], bytes ${range.start}-${range.end}` )
+      error.range = range
+      this.emit( 'error', error )
+      return
+    }
 
     var range = this.currentRange
     var digest = this._hash.digest( 'hex' )
-    var error = null
+
+    debug( 'verify:checksum', range.checksum )
+    debug( 'verify:digest  ', digest )
 
     this._hash = crypto.createHash( this.blockMap.checksumType )
 
     if( range.checksum !== digest ) {
-      error = new Error( 'Invalid checksum for range [' + range.start + ',' + range.end + ']' )
+      error = new Error( `Invalid checksum for range [${range.startLBA},${range.endLBA}], bytes ${range.start}-${range.end}` )
       error.checksum = digest
       error.range = range
       this.emit( 'error', error )
@@ -123,39 +143,94 @@ function FilterStream( blockMap, options ) {
   },
 
   /**
-   * Push a block out to the readable side,
-   * if it's in a mapped range of the block map
+   * Determine whether a chunk is in the current range
    * @private
-   * @param {Buffer} block
+   * @param {Buffer} chunk
    * @returns {Boolean}
    */
-  _pushBlock( block ) {
+  _rangeInChunk( chunk ) {
 
-    this.blocksRead++
-    this.bytesRead += block.length
+    var rangeStart = this.currentRange.start + this.currentRange.offset
 
-    if( this.currentRange == null ) return
+    var isRangeInChunk = (rangeStart >= this.position) &&
+      (rangeStart < (this.position + chunk.length))
 
-    if( !this._inRange( this.blocksRead - 1 ) ) {
-      if( this.blocksRead > this.currentRange.end ) {
-        this._verifyRange()
-        this.currentRange = this.blockMap.ranges[ ++this.rangesRead ]
+    debug( 'range-in-chunk', isRangeInChunk )
+
+    return isRangeInChunk
+
+  },
+
+  /**
+   * Chunk a given input buffer into blocks
+   * matching the blockSize and advance the
+   * current range, if necessary
+   * @param {Buffer} chunk
+   * @param {Function} next
+   */
+  _transformBlock( chunk, next ) {
+
+    var range = this.currentRange
+    var start = 0
+    var end = 0
+    var length = 0
+    var block = null
+
+    while( range && this._rangeInChunk( chunk ) ) {
+
+      start = range.start + range.offset - this.position
+      end = start + range.length - range.offset
+
+      debug( 'slice', start, '-', end )
+
+      // Cut the block, and add position & address to it
+      block = chunk.slice( start, end )
+      block.position = start
+      block.address = block.position / this.blockSize
+
+      // Make sure we don't emit buffers not matching
+      // the blockSize, in case the range's end is not in the current chunk
+      if( end > chunk.length ) {
+        length = chunk.length - start
+        debug( 'chunk:partial', length )
+        if( length % this.blockSize !== 0 ) {
+          debug( 'chunk:buffer', 'length < block size' )
+          this._chunks.push( block )
+          this._bytes += block.length
+          this.position += chunk.length - length
+          return next()
+        }
       }
-      return
+
+      // Keep track of where we are within the current range
+      range.offset += block.length
+
+      // Advance counters
+      this.bytesWritten += block.length
+      this.blocksWritten += block.length / this.blockSize
+
+      // Emit the cut block
+      debug( 'push', block )
+      this.push( block )
+
+      if( this.options.verify ) {
+        this._hash.update( block )
+      }
+
+      // Once we've read a complete range,
+      // verify it and move to the next range
+      if( range.length === range.offset ) {
+        this._verifyRange()
+        this.rangesRead++
+        range = this.currentRange = this.ranges.shift()
+        debug( 'range:next', range )
+      }
+
     }
 
-    block.address = this.blocksRead - 1
-    block.position = block.address * this.blockSize
+    this.position += chunk.length
 
-    this.blocksWritten++
-    this.bytesWritten += block.length
-    this.position = block.position + block.length
-
-    if( this.options.verify ) {
-      this._hash.update( block )
-    }
-
-    return this.push( block )
+    next()
 
   },
 
@@ -168,39 +243,64 @@ function FilterStream( blockMap, options ) {
    */
   _transform( chunk, _, next ) {
 
-    this._buffers.push( chunk )
-    this._bytes += chunk.length
+    debug( 'position', this.position )
+    debug( 'chunk', chunk.length, chunk )
 
-    if( this._bytes < this.blockSize )
+    this.bytesRead += chunk.length
+    this.blocksRead += chunk.length / this.blockSize
+
+    // We've run out of ranges; ignore everything
+    if( this.currentRange == null ) {
+      debug( 'no current range' )
       return next()
-
-    var buffer = Buffer.concat( this._buffers )
-    var offset = 0
-
-    while( buffer.length - offset >= this.blockSize ) {
-      this._pushBlock( buffer.slice( offset, offset + this.blockSize ) )
-      offset = offset + this.blockSize
     }
 
-    buffer = buffer.slice( offset )
+    // If this chunk is not in our range at all, skip it
+    if( !this._rangeInChunk( chunk ) ) {
+      debug( 'chunk:ignore' )
+      this.position += chunk.length
+      return next()
+    }
 
-    this._buffers = [ buffer ]
-    this._bytes = buffer.length
+    // If we have buffered up chunks,
+    // and they don't exceed the highWaterMark yet,
+    // buffer this chunk as well, and wait for the next chunk
+    if( this._bytes && this._bytes < this.highWaterMark ) {
+      debug( 'chunk:buffer', 'not enough bytes' )
+      this._chunks.push( chunk )
+      this._bytes += chunk.length
+      return next()
+    }
 
-    next()
+    // If we have enough buffered chunks, concat & emit them
+    if( this._bytes ) {
+      debug( 'chunk:concat', this._bytes + chunk.length )
+      this._chunks.push( chunk )
+      this._bytes += chunk.length
+      chunk = Buffer.concat( this._chunks, this._bytes )
+      this._chunks = []
+      this._bytes = 0
+    }
+
+    this._transformBlock( chunk, next )
 
   },
 
+  /**
+   * Flush out any unprocessed chunks from
+   * the internal buffer once the stream is being ended
+   * @private
+   * @param {Function} done
+   */
   _flush( done ) {
-
-    var buffer = Buffer.concat( this._buffers )
-    var block = Buffer.alloc( this.blockSize )
-
-    buffer.copy( block )
-    this._pushBlock( block )
-
-    done()
-
+    if( this._bytes ) {
+      var chunk = Buffer.concat( this._chunks, this._bytes )
+      this._chunks = []
+      this._bytes = 0
+      this._transformBlock( chunk, done )
+    } else {
+      done()
+    }
   },
 
 }

--- a/test/filter-stream.js
+++ b/test/filter-stream.js
@@ -15,14 +15,15 @@ describe( 'BlockMap.FilterStream', function() {
 
     readStream.pipe( transform )
       .on( 'data', ( block ) => {
-        blockCount++
-        assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+        blockCount += block.length / blockMap.blockSize
+        assert.equal( block.length % blockMap.blockSize, 0, 'Invalid block size: ' + block.length )
         assert.ok( block.address != null, 'block address missing' )
+        assert.ok( Number.isInteger( block.address ), 'block address must be an integer' )
         assert.ok( block.position != null, 'block position missing' )
       })
       .once( 'error', done )
       .once( 'end', function() {
-        assert.equal( this.blocksWritten, blockMap.mappedBlockCount, 'blocksRead mismatch' )
+        assert.equal( this.blocksWritten, blockMap.mappedBlockCount, 'blocksWritten mismatch' )
         assert.equal( this.bytesWritten, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesWritten mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
         assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
@@ -42,14 +43,14 @@ describe( 'BlockMap.FilterStream', function() {
 
     readStream.pipe( transform )
       .on( 'data', ( block ) => {
-        blockCount++
-        assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+        blockCount += block.length / blockMap.blockSize
+        assert.equal( block.length % blockMap.blockSize, 0, 'Invalid block size: ' + block.length )
         assert.ok( block.address != null, 'block address missing' )
         assert.ok( block.position != null, 'block position missing' )
       })
       .once( 'error', done )
       .once( 'end', function() {
-        assert.equal( this.blocksWritten, blockMap.mappedBlockCount, 'blocksRead mismatch' )
+        assert.equal( this.blocksWritten, blockMap.mappedBlockCount, 'blocksWritten mismatch' )
         assert.equal( this.bytesWritten, blockMap.mappedBlockCount * blockMap.blockSize, 'bytesWritten mismatch' )
         assert.equal( this.rangesRead, blockMap.ranges.length, 'rangesRead mismatch' )
         assert.equal( blockCount, blockMap.mappedBlockCount, 'actual blocks read mismatch' )
@@ -70,7 +71,7 @@ describe( 'BlockMap.FilterStream', function() {
 
         readStream.pipe( transform )
           .on( 'data', ( block ) => {
-            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.equal( block.length % blockMap.blockSize, 0, 'Invalid block size: ' + block.length )
             assert.ok( block.address != null, 'block address missing' )
             assert.ok( block.position != null, 'block position missing' )
           })
@@ -93,7 +94,7 @@ describe( 'BlockMap.FilterStream', function() {
 
         readStream.pipe( transform )
           .on( 'data', ( block ) => {
-            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.equal( block.length % blockMap.blockSize, 0, 'Invalid block size: ' + block.length )
             assert.ok( block.address != null, 'block address missing' )
             assert.ok( block.position != null, 'block position missing' )
           })
@@ -102,8 +103,8 @@ describe( 'BlockMap.FilterStream', function() {
             // The calculated checksum
             assert.ok( error.checksum, 'missing checksum' )
             // The faulty range's data
-            assert.strictEqual( error.range.start, 119, 'incorrect range start' )
-            assert.strictEqual( error.range.end, 133, 'incorrect range end' )
+            assert.strictEqual( error.range.startLBA, 119, 'incorrect range start' )
+            assert.strictEqual( error.range.endLBA, 133, 'incorrect range end' )
             assert.ok( error.range.checksum, 'missing "faulty" checksum' )
             done()
           })
@@ -128,7 +129,7 @@ describe( 'BlockMap.FilterStream', function() {
 
         readStream.pipe( transform )
           .on( 'data', ( block ) => {
-            assert.equal( block.length, blockMap.blockSize, 'Invalid block size' )
+            assert.equal( block.length % blockMap.blockSize, 0, 'Invalid block size: ' + block.length )
             assert.ok( block.address != null, 'block address missing' )
             assert.ok( block.position != null, 'block position missing' )
           })


### PR DESCRIPTION
**Changes:**

- Add FilterStream benchmark
- Add `debug` output to FilterStream
- Generate pre-processed ranges to simplify range bounds checking
- Optimize `_transformBlock()` to only slice & dice chunks that don't adhere to the block size, also improving performance considerably by causing fewer operations on buffers
- Fix `_flush()` to emit correctly transformed blocks
- Update emitted blocks check in tests

Change-Type: minor