### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.0.0
+
+- **refactor(filter-stream):** Optimize performance
+- **feat(read-stream):** Refactor & optimize BlockMap.ReadStream
+  - **BREAKING:** Removed `.blockInRange` property
+  - **BREAKING:** Rewrote `open()`, `close()` and `destroy()`
+    to implement the same behavior as `fs.ReadStream`
+  - **BREAKING:** `start` & `end` options will now cause only
+    partially covered regions to **NOT** be read
+  - **BREAKING:** Removed `.options`, add `.verify` instead
+  - **feat:** Added `.closed` & `.destroyed` properties
+  - **feat:** Added `.highWaterMark` getter/setter
+  - **feat:** Support `autoClose` option
+- **chore(package):** Add benchmarks
+- **chore(package):** Update mocha 3.2.0 -> 3.4.2
+
 ## 1.2.0
 
 - **fix(filter-stream):** Prevent emitting too small blocks

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,27 +14,29 @@
         * [.checksum](#BlockMap+checksum) : <code>String</code>
         * [.checksumType](#BlockMap+checksumType) : <code>Number</code>
         * [.ranges](#BlockMap+ranges) : <code>Number</code>
-        * [.parse(value, [options])](#BlockMap+parse) ⇒ <code>[BlockMap](#BlockMap)</code>
+        * [.parse(value, [options])](#BlockMap+parse) ⇒ [<code>BlockMap</code>](#BlockMap)
         * [.toString()](#BlockMap+toString) ⇒ <code>String</code>
     * _static_
         * [.FilterStream](#BlockMap.FilterStream)
             * [new FilterStream(blockMap, [options])](#new_BlockMap.FilterStream_new)
             * [.options](#BlockMap.FilterStream+options) : <code>Object</code>
-            * [.blockMap](#BlockMap.FilterStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
+            * [.blockMap](#BlockMap.FilterStream+blockMap) : [<code>BlockMap</code>](#BlockMap)
             * [.blockSize](#BlockMap.FilterStream+blockSize) : <code>Number</code>
-            * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>BlockMap.Range</code>
             * [.rangesRead](#BlockMap.FilterStream+rangesRead) : <code>Number</code>
             * [.blocksRead](#BlockMap.FilterStream+blocksRead) : <code>Number</code>
             * [.bytesRead](#BlockMap.FilterStream+bytesRead) : <code>Number</code>
             * [.blocksWritten](#BlockMap.FilterStream+blocksWritten) : <code>Number</code>
             * [.bytesWritten](#BlockMap.FilterStream+bytesWritten) : <code>Number</code>
             * [.position](#BlockMap.FilterStream+position) : <code>Number</code>
+            * [.ranges](#BlockMap.FilterStream+ranges) : <code>Array.&lt;Object&gt;</code>
+            * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>Object</code>
+            * [._transformBlock(chunk, next)](#BlockMap.FilterStream+_transformBlock)
         * [.ReadStream](#BlockMap.ReadStream)
             * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
             * [.fd](#BlockMap.ReadStream+fd) : <code>Number</code>
             * [.path](#BlockMap.ReadStream+path) : <code>String</code>
             * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
-            * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
+            * [.blockMap](#BlockMap.ReadStream+blockMap) : [<code>BlockMap</code>](#BlockMap)
             * [.blockSize](#BlockMap.ReadStream+blockSize) : <code>Number</code>
             * [.verify](#BlockMap.ReadStream+verify) : <code>Boolean</code>
             * [.currentRange](#BlockMap.ReadStream+currentRange) : <code>BlockMap.Range</code>
@@ -49,15 +51,15 @@
             * [.close([callback])](#BlockMap.ReadStream+close)
             * [.destroy()](#BlockMap.ReadStream+destroy)
         * [.versions](#BlockMap.versions) : <code>Array</code>
-        * [.create([options])](#BlockMap.create) ⇒ <code>[BlockMap](#BlockMap)</code>
-        * [.fromJSON(data)](#BlockMap.fromJSON) ⇒ <code>[BlockMap](#BlockMap)</code>
-        * [.createReadStream(filename, blockMap, [options])](#BlockMap.createReadStream) ⇒ <code>[ReadStream](#BlockMap.ReadStream)</code>
-        * [.createFilterStream(blockMap, [options])](#BlockMap.createFilterStream) ⇒ <code>[FilterStream](#BlockMap.FilterStream)</code>
-        * [.parse(value, [blockMap], [options])](#BlockMap.parse) ⇒ <code>[BlockMap](#BlockMap)</code>
+        * [.create([options])](#BlockMap.create) ⇒ [<code>BlockMap</code>](#BlockMap)
+        * [.fromJSON(data)](#BlockMap.fromJSON) ⇒ [<code>BlockMap</code>](#BlockMap)
+        * [.createReadStream(filename, blockMap, [options])](#BlockMap.createReadStream) ⇒ [<code>ReadStream</code>](#BlockMap.ReadStream)
+        * [.createFilterStream(blockMap, [options])](#BlockMap.createFilterStream) ⇒ [<code>FilterStream</code>](#BlockMap.FilterStream)
+        * [.parse(value, [blockMap], [options])](#BlockMap.parse) ⇒ [<code>BlockMap</code>](#BlockMap)
         * [.stringify(blockMap)](#BlockMap.stringify) ⇒ <code>String</code>
 
 
--
+* * *
 
 <a name="new_BlockMap_new"></a>
 
@@ -77,86 +79,86 @@ BlockMap
     - [.ranges] <code>Array</code> <code> = []</code>
 
 
--
+* * *
 
 <a name="BlockMap+version"></a>
 
 ### blockMap.version : <code>String</code>
 format version
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+imageSize"></a>
 
 ### blockMap.imageSize : <code>Number</code>
 size of the image in bytes
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+blockSize"></a>
 
 ### blockMap.blockSize : <code>Number</code>
 size of a block in bytes
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+blockCount"></a>
 
 ### blockMap.blockCount : <code>Number</code>
 total number of blocks in image
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+mappedBlockCount"></a>
 
 ### blockMap.mappedBlockCount : <code>Number</code>
 number of mapped blocks
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+checksum"></a>
 
 ### blockMap.checksum : <code>String</code>
 bmap file checksum
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+checksumType"></a>
 
 ### blockMap.checksumType : <code>Number</code>
 checksum algorithm
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+ranges"></a>
 
 ### blockMap.ranges : <code>Number</code>
 block ranges
 
-**Kind**: instance property of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance property of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap+parse"></a>
 
-### blockMap.parse(value, [options]) ⇒ <code>[BlockMap](#BlockMap)</code>
+### blockMap.parse(value, [options]) ⇒ [<code>BlockMap</code>](#BlockMap)
 Parse a .bmap formatted input
 
-**Kind**: instance method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance method of [<code>BlockMap</code>](#BlockMap)  
 **Params**
 
 - value <code>String</code> | <code>Buffer</code>
@@ -164,38 +166,40 @@ Parse a .bmap formatted input
     - [.verify] <code>Boolean</code> <code> = true</code> - verify range checksums
 
 
--
+* * *
 
 <a name="BlockMap+toString"></a>
 
 ### blockMap.toString() ⇒ <code>String</code>
 Stringify the block map into .bmap format
 
-**Kind**: instance method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: instance method of [<code>BlockMap</code>](#BlockMap)  
 **Returns**: <code>String</code> - xml  
 
--
+* * *
 
 <a name="BlockMap.FilterStream"></a>
 
 ### BlockMap.FilterStream
-**Kind**: static class of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static class of [<code>BlockMap</code>](#BlockMap)  
 
 * [.FilterStream](#BlockMap.FilterStream)
     * [new FilterStream(blockMap, [options])](#new_BlockMap.FilterStream_new)
     * [.options](#BlockMap.FilterStream+options) : <code>Object</code>
-    * [.blockMap](#BlockMap.FilterStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
+    * [.blockMap](#BlockMap.FilterStream+blockMap) : [<code>BlockMap</code>](#BlockMap)
     * [.blockSize](#BlockMap.FilterStream+blockSize) : <code>Number</code>
-    * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>BlockMap.Range</code>
     * [.rangesRead](#BlockMap.FilterStream+rangesRead) : <code>Number</code>
     * [.blocksRead](#BlockMap.FilterStream+blocksRead) : <code>Number</code>
     * [.bytesRead](#BlockMap.FilterStream+bytesRead) : <code>Number</code>
     * [.blocksWritten](#BlockMap.FilterStream+blocksWritten) : <code>Number</code>
     * [.bytesWritten](#BlockMap.FilterStream+bytesWritten) : <code>Number</code>
     * [.position](#BlockMap.FilterStream+position) : <code>Number</code>
+    * [.ranges](#BlockMap.FilterStream+ranges) : <code>Array.&lt;Object&gt;</code>
+    * [.currentRange](#BlockMap.FilterStream+currentRange) : <code>Object</code>
+    * [._transformBlock(chunk, next)](#BlockMap.FilterStream+_transformBlock)
 
 
--
+* * *
 
 <a name="new_BlockMap.FilterStream_new"></a>
 
@@ -204,114 +208,139 @@ FilterStream
 
 **Params**
 
-- blockMap <code>[BlockMap](#BlockMap)</code> - the block map
+- blockMap [<code>BlockMap</code>](#BlockMap) - the block map
 - [options] <code>Object</code> - options
     - [.verify] <code>Boolean</code> <code> = true</code> - verify range checksums
 
 
--
+* * *
 
 <a name="BlockMap.FilterStream+options"></a>
 
 #### filterStream.options : <code>Object</code>
 options
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+blockMap"></a>
 
-#### filterStream.blockMap : <code>[BlockMap](#BlockMap)</code>
+#### filterStream.blockMap : [<code>BlockMap</code>](#BlockMap)
 The block map
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+blockSize"></a>
 
 #### filterStream.blockSize : <code>Number</code>
 Size of a mapped block in bytes
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
-
-<a name="BlockMap.FilterStream+currentRange"></a>
-
-#### filterStream.currentRange : <code>BlockMap.Range</code>
-Range being currently processed
-
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
-
--
+* * *
 
 <a name="BlockMap.FilterStream+rangesRead"></a>
 
 #### filterStream.rangesRead : <code>Number</code>
 Number of block map ranges read
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+blocksRead"></a>
 
 #### filterStream.blocksRead : <code>Number</code>
 Number of blocks read
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+bytesRead"></a>
 
 #### filterStream.bytesRead : <code>Number</code>
 Number of bytes read
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+blocksWritten"></a>
 
 #### filterStream.blocksWritten : <code>Number</code>
 Number of bytes written
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+bytesWritten"></a>
 
 #### filterStream.bytesWritten : <code>Number</code>
 Number of bytes written
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
 
 <a name="BlockMap.FilterStream+position"></a>
 
 #### filterStream.position : <code>Number</code>
 Current offset in bytes
 
-**Kind**: instance property of <code>[FilterStream](#BlockMap.FilterStream)</code>  
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
 
--
+* * *
+
+<a name="BlockMap.FilterStream+ranges"></a>
+
+#### filterStream.ranges : <code>Array.&lt;Object&gt;</code>
+Ranges
+
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
+
+* * *
+
+<a name="BlockMap.FilterStream+currentRange"></a>
+
+#### filterStream.currentRange : <code>Object</code>
+Range being currently processed
+
+**Kind**: instance property of [<code>FilterStream</code>](#BlockMap.FilterStream)  
+
+* * *
+
+<a name="BlockMap.FilterStream+_transformBlock"></a>
+
+#### filterStream._transformBlock(chunk, next)
+Chunk a given input buffer into blocks
+matching the blockSize and advance the
+current range, if necessary
+
+**Kind**: instance method of [<code>FilterStream</code>](#BlockMap.FilterStream)  
+**Params**
+
+- chunk <code>Buffer</code>
+- next <code>function</code>
+
+
+* * *
 
 <a name="BlockMap.ReadStream"></a>
 
 ### BlockMap.ReadStream
-**Kind**: static class of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static class of [<code>BlockMap</code>](#BlockMap)  
 
 * [.ReadStream](#BlockMap.ReadStream)
     * [new ReadStream(filename, blockMap, [options])](#new_BlockMap.ReadStream_new)
     * [.fd](#BlockMap.ReadStream+fd) : <code>Number</code>
     * [.path](#BlockMap.ReadStream+path) : <code>String</code>
     * [.flags](#BlockMap.ReadStream+flags) : <code>String</code>
-    * [.blockMap](#BlockMap.ReadStream+blockMap) : <code>[BlockMap](#BlockMap)</code>
+    * [.blockMap](#BlockMap.ReadStream+blockMap) : [<code>BlockMap</code>](#BlockMap)
     * [.blockSize](#BlockMap.ReadStream+blockSize) : <code>Number</code>
     * [.verify](#BlockMap.ReadStream+verify) : <code>Boolean</code>
     * [.currentRange](#BlockMap.ReadStream+currentRange) : <code>BlockMap.Range</code>
@@ -327,7 +356,7 @@ Current offset in bytes
     * [.destroy()](#BlockMap.ReadStream+destroy)
 
 
--
+* * *
 
 <a name="new_BlockMap.ReadStream_new"></a>
 
@@ -337,7 +366,7 @@ ReadStream
 **Params**
 
 - filename <code>String</code> - image path
-- blockMap <code>[BlockMap](#BlockMap)</code> - image's blockmap
+- blockMap [<code>BlockMap</code>](#BlockMap) - image's blockmap
 - [options] <code>Object</code> - options
     - [.fd] <code>Number</code> <code> = </code> - file descriptor
     - [.flags] <code>String</code> <code> = &#x27;r&#x27;</code> - fs.open() flags
@@ -347,180 +376,180 @@ ReadStream
     - [.end] <code>Number</code> - byte offset in file to stop at
 
 
--
+* * *
 
 <a name="BlockMap.ReadStream+fd"></a>
 
 #### readStream.fd : <code>Number</code>
 File descriptor
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+path"></a>
 
 #### readStream.path : <code>String</code>
 File path
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+flags"></a>
 
 #### readStream.flags : <code>String</code>
 File open flags
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+blockMap"></a>
 
-#### readStream.blockMap : <code>[BlockMap](#BlockMap)</code>
+#### readStream.blockMap : [<code>BlockMap</code>](#BlockMap)
 The block map
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+blockSize"></a>
 
 #### readStream.blockSize : <code>Number</code>
 Size of a mapped block in bytes
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+verify"></a>
 
 #### readStream.verify : <code>Boolean</code>
 Whether or not to verify range checksums
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+currentRange"></a>
 
 #### readStream.currentRange : <code>BlockMap.Range</code>
 Range being currently processed
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+rangesRead"></a>
 
 #### readStream.rangesRead : <code>Number</code>
 Number of block map ranges read
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+blocksRead"></a>
 
 #### readStream.blocksRead : <code>Number</code>
 Number of blocks read
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+bytesRead"></a>
 
 #### readStream.bytesRead : <code>Number</code>
 Number of bytes read
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+position"></a>
 
 #### readStream.position : <code>Number</code>
 Current offset in bytes
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+start"></a>
 
 #### readStream.start : <code>Number</code>
 Position start offset in bytes
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+end"></a>
 
 #### readStream.end : <code>Number</code>
 End offset in bytes
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+closed"></a>
 
 #### readStream.closed : <code>Boolean</code>
 Whether the stream has been closed
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+destroyed"></a>
 
 #### readStream.destroyed : <code>Boolean</code>
 Whether the stream has been destroyed
 
-**Kind**: instance property of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance property of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.ReadStream+close"></a>
 
 #### readStream.close([callback])
 Close the stream, and the underlying file handle
 
-**Kind**: instance method of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance method of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 **Params**
 
 - [callback] <code>function</code> - callback(error)
 
 
--
+* * *
 
 <a name="BlockMap.ReadStream+destroy"></a>
 
 #### readStream.destroy()
 Destroy the stream, release any internal resources
 
-**Kind**: instance method of <code>[ReadStream](#BlockMap.ReadStream)</code>  
+**Kind**: instance method of [<code>ReadStream</code>](#BlockMap.ReadStream)  
 
--
+* * *
 
 <a name="BlockMap.versions"></a>
 
 ### BlockMap.versions : <code>Array</code>
 Supported .bmap format versions
 
-**Kind**: static constant of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static constant of [<code>BlockMap</code>](#BlockMap)  
 
--
+* * *
 
 <a name="BlockMap.create"></a>
 
-### BlockMap.create([options]) ⇒ <code>[BlockMap](#BlockMap)</code>
+### BlockMap.create([options]) ⇒ [<code>BlockMap</code>](#BlockMap)
 Create a new block map
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
 **Params**
 
 - [options] <code>Object</code>
@@ -534,32 +563,32 @@ Create a new block map
     - [.ranges] <code>Array</code> <code> = []</code>
 
 
--
+* * *
 
 <a name="BlockMap.fromJSON"></a>
 
-### BlockMap.fromJSON(data) ⇒ <code>[BlockMap](#BlockMap)</code>
+### BlockMap.fromJSON(data) ⇒ [<code>BlockMap</code>](#BlockMap)
 Create a block map from it's JSON representation
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
 **Params**
 
 - data <code>String</code> | <code>Object</code>
 
 
--
+* * *
 
 <a name="BlockMap.createReadStream"></a>
 
-### BlockMap.createReadStream(filename, blockMap, [options]) ⇒ <code>[ReadStream](#BlockMap.ReadStream)</code>
+### BlockMap.createReadStream(filename, blockMap, [options]) ⇒ [<code>ReadStream</code>](#BlockMap.ReadStream)
 Create a ReadStream for an image with a block map
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
-**Returns**: <code>[ReadStream](#BlockMap.ReadStream)</code> - stream  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
+**Returns**: [<code>ReadStream</code>](#BlockMap.ReadStream) - stream  
 **Params**
 
 - filename <code>String</code>
-- blockMap <code>[BlockMap](#BlockMap)</code> - image's blockmap
+- blockMap [<code>BlockMap</code>](#BlockMap) - image's blockmap
 - [options] <code>Object</code> - options
     - [.fd] <code>Number</code> <code> = </code> - file descriptor
     - [.flags] <code>String</code> <code> = &#x27;r&#x27;</code> - fs.open() flags
@@ -569,51 +598,51 @@ Create a ReadStream for an image with a block map
     - [.end] <code>Number</code> - byte offset in file to stop at
 
 
--
+* * *
 
 <a name="BlockMap.createFilterStream"></a>
 
-### BlockMap.createFilterStream(blockMap, [options]) ⇒ <code>[FilterStream](#BlockMap.FilterStream)</code>
+### BlockMap.createFilterStream(blockMap, [options]) ⇒ [<code>FilterStream</code>](#BlockMap.FilterStream)
 Create a FilterStream with a given block map
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
-**Returns**: <code>[FilterStream](#BlockMap.FilterStream)</code> - stream  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
+**Returns**: [<code>FilterStream</code>](#BlockMap.FilterStream) - stream  
 **Params**
 
-- blockMap <code>[BlockMap](#BlockMap)</code>
+- blockMap [<code>BlockMap</code>](#BlockMap)
 - [options] <code>Object</code>
     - [.verify] <code>Boolean</code> <code> = true</code> - verify range checksums
 
 
--
+* * *
 
 <a name="BlockMap.parse"></a>
 
-### BlockMap.parse(value, [blockMap], [options]) ⇒ <code>[BlockMap](#BlockMap)</code>
+### BlockMap.parse(value, [blockMap], [options]) ⇒ [<code>BlockMap</code>](#BlockMap)
 Parse a .bmap file
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
 **Params**
 
 - value <code>String</code> | <code>Buffer</code> - input
-- [blockMap] <code>[BlockMap](#BlockMap)</code> - BlockMap instance to populate
+- [blockMap] [<code>BlockMap</code>](#BlockMap) - BlockMap instance to populate
 - [options] <code>Object</code> - options
     - [.verify] <code>Boolean</code> - verify range checksums
 
 
--
+* * *
 
 <a name="BlockMap.stringify"></a>
 
 ### BlockMap.stringify(blockMap) ⇒ <code>String</code>
 Stringify a block map into .bmap format
 
-**Kind**: static method of <code>[BlockMap](#BlockMap)</code>  
+**Kind**: static method of [<code>BlockMap</code>](#BlockMap)  
 **Returns**: <code>String</code> - xml  
 **Params**
 
-- blockMap <code>[BlockMap](#BlockMap)</code> - BlockMap instance
+- blockMap [<code>BlockMap</code>](#BlockMap) - BlockMap instance
 
 
--
+* * *
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockmap",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Tizen's block map format",
   "license": "MIT",
   "author": "Jonas Hermsmeier <jhermsmeier@gmail.com> (https://jhermsmeier.de)",


### PR DESCRIPTION
**Changes:**

- **refactor(filter-stream):** Optimize performance
- **feat(read-stream):** Refactor & optimize BlockMap.ReadStream
  - **BREAKING:** Removed `.blockInRange` property
  - **BREAKING:** Rewrote `open()`, `close()` and `destroy()`
    to implement the same behavior as `fs.ReadStream`
  - **BREAKING:** `start` & `end` options will now cause only
    partially covered regions to **NOT** be read
  - **BREAKING:** Removed `.options`, add `.verify` instead
  - **feat:** Added `.closed` & `.destroyed` properties
  - **feat:** Added `.highWaterMark` getter/setter
  - **feat:** Support `autoClose` option
- **chore(package):** Add benchmarks
- **chore(package):** Update mocha 3.2.0 -> 3.4.2

Change-Type: major