### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+- **fix(package):** Fix `nanobench` not being a dev dependency
+- **chore(package):** Update mocha 3.4.2 -> 3.5.0
+
 ## 2.0.0
 
 - **refactor(filter-stream):** Optimize performance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockmap",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tizen's block map format",
   "license": "MIT",
   "author": "Jonas Hermsmeier <jhermsmeier@gmail.com> (https://jhermsmeier.de)",


### PR DESCRIPTION
- **fix(package):** Fix `nanobench` not being a dev dependency
- **chore(package):** Update mocha 3.4.2 -> 3.5.0
- **chore(appveyor):** Explicitly specify Node 8