### PR TITLE
chore(appveyor): Explicitly specify Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - stable
+  - "8"
   - "6"
   - "4"
 script: npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ init:
   - git config --global core.autocrlf false
 environment:
   matrix:
-    - nodejs_version: ""
+    - nodejs_version: "8"
     - nodejs_version: "6"
     - nodejs_version: "4"
 install:


### PR DESCRIPTION
This explicitly specifies the Node version for the latest
version in the matrix, in hope this will fix sporadic
combustion of the Node 8 CI builds.

Change-Type: patch